### PR TITLE
csv_download(): Re-enable unreachable code

### DIFF
--- a/src/sa_web/views.py
+++ b/src/sa_web/views.py
@@ -533,7 +533,7 @@ def csv_download(request, path):
         'ACCEPT': 'text/csv'
     }
     cookies = {'sessionid': api_session_cookie} if api_session_cookie else {}
-    return proxy_view(request, url, requests_args={
+    response = proxy_view(request, url, requests_args={
         'headers': headers,
         'cookies': cookies
     })


### PR DESCRIPTION
In the current code, the unconditional `return` statement on line 536 makes the remaining lines unreachable.

This pull request follows the examples on lines 460, 486, and 509 in a way that re-enables that code.