### PR TITLE
 str.endswith(suffix) can be a tuple of suffixes to look for

### DIFF
--- a/src/project/settings.py
+++ b/src/project/settings.py
@@ -394,7 +394,7 @@ if 'PACKAGE' not in SHAREABOUTS:
 
 # Load in any social auth keys and secrets from the environment
 for key in os.environ:
-    if key.startswith('SOCIAL_AUTH_') and (key.endswith('_KEY') or key.endswith('_SECRET') or key.endswith('_REDIRECT')):
+    if key.startswith('SOCIAL_AUTH_') and key.endswith(('_KEY', '_REDIRECT', '_SECRET')):
         globals()[key] = os.environ[key]
 
 


### PR DESCRIPTION
% `ruff rule PIE810 ` # https://docs.astral.sh/ruff/rules/multiple-starts-ends-with
# multiple-starts-ends-with (PIE810)

Derived from the **flake8-pie** linter.

Fix is always available.

## What it does
Checks for `startswith` or `endswith` calls on the same value with different prefixes or suffixes.

## Why is this bad?
The `startswith` and `endswith` methods accept tuples of prefixes or suffixes respectively. Passing a tuple of prefixes or suffixes is more efficient and readable than calling the method multiple times.

## Example
```python
msg = "Hello, world!"
if msg.startswith("Hello") or msg.startswith("Hi"):
    print("Greetings!")
```

Use instead:
```python
msg = "Hello, world!"
if msg.startswith(("Hello", "Hi")):
    print("Greetings!")
```

## Fix safety
This rule's fix is unsafe, as in some cases, it will be unable to determine whether the argument to an existing `.startswith` or `.endswith` call is a tuple. For example, given `msg.startswith(x) or msg.startswith(y)`, if `x` or `y` is a tuple, and the semantic model is unable to detect it as such, the rule will suggest `msg.startswith((x, y))`, which will error at runtime.

## References
- [Python documentation: `str.startswith`](https://docs.python.org/3/library/stdtypes.html#str.startswith)
- [Python documentation: `str.endswith`](https://docs.python.org/3/library/stdtypes.html#str.endswith)