### PR TITLE
Add the ability to toggle the visibility of the ticker (side bar)

### DIFF
--- a/src/flavors/cycle3/jstemplates/sidebar-toggle-control.html
+++ b/src/flavors/cycle3/jstemplates/sidebar-toggle-control.html
@@ -1,5 +1,15 @@
 <!-- Sidebar Toggle Button for the sidebar-collapse-ext.js extension -->
 <button id="sidebar-toggle">
-  <span class="collapse-icon" aria-label="{{#_}}Hide sidebar{{/_}}">🞂</span>
-  <span class="expand-icon" aria-label="{{#_}}Show sidebar{{/_}}">🞀</span>
+  <span class="collapse-icon" aria-label="{{#_}}Hide sidebar{{/_}}">
+    <!-- Triangle facing left -->
+    <svg viewBox="-4 0 16 16">
+      <path d="M 0,0 L 8,8 L 0,16 Z" />
+    </svg>
+  </span>
+  <span class="expand-icon" aria-label="{{#_}}Show sidebar{{/_}}">
+    <!-- Triangle facing right -->
+    <svg viewBox="-4 0 16 16">
+      <path d="M 8,0 L 0,8 L 8,16 Z" />
+    </svg>
+  </span>
 </button>

--- a/src/flavors/cycle3/jstemplates/sidebar-toggle-control.html
+++ b/src/flavors/cycle3/jstemplates/sidebar-toggle-control.html
@@ -1,0 +1,5 @@
+<!-- Sidebar Toggle Button for the sidebar-collapse-ext.js extension -->
+<button id="sidebar-toggle">
+  <span class="collapse-icon" aria-label="{{#_}}Hide sidebar{{/_}}">🞂</span>
+  <span class="expand-icon" aria-label="{{#_}}Show sidebar{{/_}}">🞀</span>
+</button>

--- a/src/flavors/cycle3/static/css/custom.css
+++ b/src/flavors/cycle3/static/css/custom.css
@@ -1,5 +1,6 @@
 @import url('/static/css/city-wide-ext.css');
 @import url('/static/css/language-picker.css');
+@import url('/static/css/sidebar-collapse-ext.css');
 
 /*
  * This CSS file follows the default Shareabouts style.css.

--- a/src/flavors/cycle3/static/css/sidebar-collapse-ext.css
+++ b/src/flavors/cycle3/static/css/sidebar-collapse-ext.css
@@ -1,0 +1,53 @@
+#sidebar-toggle {
+  display: none;
+}
+
+@media only screen and (min-width: 960px) {
+  #sidebar-toggle {
+    display: flex;
+    position: fixed;
+    top: 50%;
+    right: var(--ticker-width, 18em);
+    width: 1.5rem;
+    height: 3rem;
+    margin-top: -1.5rem;
+    background-color: var(--iia-dark-blue);
+    color: white;
+    border: none;
+    border-radius: 0.5rem 0 0 0.5rem;
+    cursor: pointer;
+    align-items: center;
+    justify-content: center;
+    padding: 0;
+    box-shadow: -2px 0 5px rgba(0,0,0,0.2);
+    z-index: 1000;
+    transition: right 0.3s ease;
+  }
+
+  #sidebar-toggle:hover {
+    background-color: var(--iia-urban-pink);
+  }
+
+  body.sidebar-collapsed #sidebar-toggle {
+    right: 0;
+  }
+
+  #ticker {
+    transition: transform 0.3s ease;
+  }
+
+  body.sidebar-collapsed #ticker {
+    transform: translateX(100%);
+  }
+
+  #map-container {
+    transition: width 0.3s ease, right 0.3s ease;
+  }
+
+  body.sidebar-collapsed.activity-enabled.content-visible #map-container,
+  body.sidebar-collapsed.activity-enabled #map-container,
+  body.sidebar-collapsed.content-visible #map-container,
+  body.sidebar-collapsed #map-container {
+    width: 100%;
+  }
+}

--- a/src/flavors/cycle3/static/css/sidebar-collapse-ext.css
+++ b/src/flavors/cycle3/static/css/sidebar-collapse-ext.css
@@ -2,7 +2,7 @@
   display: none;
 }
 
-@media only screen and (min-width: 960px) {
+@media only screen and (width >= 60rem) {
   #sidebar-toggle {
     display: flex;
     position: fixed;
@@ -18,6 +18,7 @@
     cursor: pointer;
     align-items: center;
     justify-content: center;
+    line-height: 1;
     padding: 0;
     box-shadow: -2px 0 5px rgba(0,0,0,0.2);
     z-index: 1000;
@@ -49,5 +50,17 @@
   body.sidebar-collapsed.content-visible #map-container,
   body.sidebar-collapsed #map-container {
     width: 100%;
+  }
+
+  #content {
+    transition: right 0.3s ease, left 0.3s ease;
+  }
+
+  body.sidebar-collapsed.activity-enabled.content-visible #content,
+  body.sidebar-collapsed.activity-enabled #content,
+  body.sidebar-collapsed.content-visible #content,
+  body.sidebar-collapsed #content {
+    left: calc(var(--content-left) + var(--ticker-width));
+    right: 0;
   }
 }

--- a/src/flavors/cycle3/static/css/sidebar-collapse-ext.css
+++ b/src/flavors/cycle3/static/css/sidebar-collapse-ext.css
@@ -25,6 +25,22 @@
     transition: right 0.3s ease;
   }
 
+  #sidebar-toggle .collapse-icon {
+    display: block;
+  }
+
+  #sidebar-toggle .expand-icon {
+    display: none;
+  }
+
+  body.sidebar-collapsed #sidebar-toggle .collapse-icon {
+    display: none;
+  }
+
+  body.sidebar-collapsed #sidebar-toggle .expand-icon {
+    display: block;
+  }
+
   #sidebar-toggle:hover {
     background-color: var(--iia-urban-pink);
   }

--- a/src/flavors/cycle3/static/css/sidebar-collapse-ext.css
+++ b/src/flavors/cycle3/static/css/sidebar-collapse-ext.css
@@ -45,6 +45,16 @@
     background-color: var(--iia-urban-pink);
   }
 
+  #sidebar-toggle svg {
+    width: 1rem;
+    height: 1rem;
+  }
+
+  #sidebar-toggle svg path {
+    stroke: none;
+    fill: currentColor;
+  }
+
   body.sidebar-collapsed #sidebar-toggle {
     right: 0;
   }

--- a/src/flavors/cycle3/static/js/sidebar-collapse-ext.js
+++ b/src/flavors/cycle3/static/js/sidebar-collapse-ext.js
@@ -1,31 +1,30 @@
-(function($) {
-  $(function() {
-    var $body = $('body');
+(function() {
+  const body = document.body;
+  const toggleBtn = document.getElementById('sidebar-toggle');
+  const ticker = document.getElementById('ticker');
 
-    var $toggleBtn = $('<button id="sidebar-toggle" aria-label="Toggle Sidebar">' +
-      '<span class="collapse-icon">🞂</span>' +
-      '<span class="expand-icon" style="display: none;">🞀</span>' +
-    '</button>');
+  toggleBtn.setAttribute('aria-controls', ticker.id);
 
-    $body.append($toggleBtn);
+  function updateSidebarCollapsedState() {
+    const isCollapsed = body.classList.contains('sidebar-collapsed');
 
-    $toggleBtn.on('click', function() {
-      $body.toggleClass('sidebar-collapsed');
+    ticker.setAttribute('aria-hidden', isCollapsed);
+    toggleBtn.setAttribute('aria-expanded', !isCollapsed);
+  }
 
-      if ($body.hasClass('sidebar-collapsed')) {
-        $toggleBtn.find('.collapse-icon').hide();
-        $toggleBtn.find('.expand-icon').show();
-      } else {
-        $toggleBtn.find('.collapse-icon').show();
-        $toggleBtn.find('.expand-icon').hide();
+  toggleBtn.addEventListener('click', function() {
+    body.classList.toggle('sidebar-collapsed');
+
+    updateSidebarCollapsedState();
+
+    // Invalidate map size after transition to ensure tiles load properly
+    setTimeout(function() {
+      if (window.app?.appView?.mapView?.map) {
+        window.app.appView.mapView.map.invalidateSize();
       }
-
-      // Invalidate map size after transition to ensure tiles load properly
-      setTimeout(function() {
-        if (window.app?.appView?.mapView?.map) {
-          window.app.appView.mapView.map.invalidateSize();
-        }
-      }, 350); // 350ms to ensure the 300ms transition completes
-    });
+    }, 350); // 350ms to ensure the 300ms CSS transition completes
   });
-})(jQuery);
+
+  // Initialize the sidebar collapsed state
+  updateSidebarCollapsedState();
+})();

--- a/src/flavors/cycle3/static/js/sidebar-collapse-ext.js
+++ b/src/flavors/cycle3/static/js/sidebar-collapse-ext.js
@@ -1,0 +1,31 @@
+(function($) {
+  $(function() {
+    var $body = $('body');
+
+    var $toggleBtn = $('<button id="sidebar-toggle" aria-label="Toggle Sidebar">' +
+      '<span class="collapse-icon">🞂</span>' +
+      '<span class="expand-icon" style="display: none;">🞀</span>' +
+    '</button>');
+
+    $body.append($toggleBtn);
+
+    $toggleBtn.on('click', function() {
+      $body.toggleClass('sidebar-collapsed');
+
+      if ($body.hasClass('sidebar-collapsed')) {
+        $toggleBtn.find('.collapse-icon').hide();
+        $toggleBtn.find('.expand-icon').show();
+      } else {
+        $toggleBtn.find('.collapse-icon').show();
+        $toggleBtn.find('.expand-icon').hide();
+      }
+
+      // Invalidate map size after transition to ensure tiles load properly
+      setTimeout(function() {
+        if (window.app?.appView?.mapView?.map) {
+          window.app.appView.mapView.map.invalidateSize();
+        }
+      }, 350); // 350ms to ensure the 300ms transition completes
+    });
+  });
+})(jQuery);

--- a/src/flavors/cycle3/static/js/sidebar-collapse-ext.js
+++ b/src/flavors/cycle3/static/js/sidebar-collapse-ext.js
@@ -1,5 +1,11 @@
 (function() {
   const body = document.body;
+  const sidebarToggleTpl = Handlebars.templates['sidebar-toggle-control'];
+  const sidebarToggle = document.createElement('div');
+  sidebarToggle.id = 'sidebar-toggle-container';
+  sidebarToggle.innerHTML = sidebarToggleTpl();
+  body.append(sidebarToggle);
+
   const toggleBtn = document.getElementById('sidebar-toggle');
   const ticker = document.getElementById('ticker');
 

--- a/src/flavors/cycle3/templates/index.html
+++ b/src/flavors/cycle3/templates/index.html
@@ -110,4 +110,5 @@
 <script src="{% static 'js/map-view-padding-ext.js' %}"></script>
 <script src="{% static 'js/map-view-initial-extents-ext.js' %}"></script>
 <script src="{% static 'js/color-scheme-ext.js' %}"></script>
+<script src="{% static 'js/sidebar-collapse-ext.js' %}"></script>
 {% endblock %}

--- a/src/flavors/cycle3/templates/index.html
+++ b/src/flavors/cycle3/templates/index.html
@@ -89,8 +89,8 @@
 {% block includes %}
 <!-- Sidebar Toggle Button for the sidebar-collapse-ext.js extension -->
 <button id="sidebar-toggle">
-  <span class="collapse-icon" aria-label="Hide sidebar">🞂</span>
-  <span class="expand-icon" aria-label="Show sidebar">🞀</span>
+  <span class="collapse-icon" aria-label="{% translate 'Hide sidebar' %}">🞂</span>
+  <span class="expand-icon" aria-label="{% translate 'Show sidebar' %}">🞀</span>
 </button>
 
 <link rel="stylesheet" href="https://unpkg.com/select2@4.1.0-rc.0/dist/css/select2.min.css">

--- a/src/flavors/cycle3/templates/index.html
+++ b/src/flavors/cycle3/templates/index.html
@@ -87,6 +87,12 @@
   Analytics, custom JS, and such go here
  -->
 {% block includes %}
+<!-- Sidebar Toggle Button for the sidebar-collapse-ext.js extension -->
+<button id="sidebar-toggle">
+  <span class="collapse-icon" aria-label="Hide sidebar">🞂</span>
+  <span class="expand-icon" aria-label="Show sidebar">🞀</span>
+</button>
+
 <link rel="stylesheet" href="https://unpkg.com/select2@4.1.0-rc.0/dist/css/select2.min.css">
 
 <script src="https://unpkg.com/@turf/turf@6/turf.min.js"></script>

--- a/src/flavors/cycle3/templates/index.html
+++ b/src/flavors/cycle3/templates/index.html
@@ -87,12 +87,6 @@
   Analytics, custom JS, and such go here
  -->
 {% block includes %}
-<!-- Sidebar Toggle Button for the sidebar-collapse-ext.js extension -->
-<button id="sidebar-toggle">
-  <span class="collapse-icon" aria-label="{% translate 'Hide sidebar' %}">🞂</span>
-  <span class="expand-icon" aria-label="{% translate 'Show sidebar' %}">🞀</span>
-</button>
-
 <link rel="stylesheet" href="https://unpkg.com/select2@4.1.0-rc.0/dist/css/select2.min.css">
 
 <script src="https://unpkg.com/@turf/turf@6/turf.min.js"></script>


### PR DESCRIPTION
This PR introduces a new feature to collapse the right-hand sidebar (ticker) on large screens (width >= 60rem / 960px). By collapsing the sidebar, users can free up screen real estate, allowing the map and content panels to utilize the full width of the window.

* Closes #83 

**Changes Made**

* Sidebar Toggle UI: Added a new toggle button on the left edge of the sidebar (🞂 to collapse and 🞀 to expand); included translatable ARIA labels.
* CSS Transitions (sidebar-collapse-ext.css):
  * Added smooth sliding transitions for the #ticker (translateX(100%)) and the toggle button itself.
  * Dynamically updates #map-container to expand to 100% width when the sidebar is collapsed.
  * Dynamically updates #content to shift into the newly freed space (right: 0 and left: calc(...)) without breaking its default margins.
* JavaScript Logic (sidebar-collapse-ext.js):
  * Toggles a .sidebar-collapsed class on the body.
  * Triggers `window.app.appView.mapView.map.invalidateSize()` after the CSS transition completes (350ms) to ensure Leaflet properly redraws map tiles in the expanded container.
  * Manages ARIA state management
* Asset Registration: Imported the new CSS extension in custom.css and loaded the JS script via index.html.
