### PR TITLE
Make the list view accessible on mobile

### DIFF
--- a/src/flavors/cycle3/static/css/custom.css
+++ b/src/flavors/cycle3/static/css/custom.css
@@ -1772,7 +1772,7 @@ label {
     margin-left: 1.25rem;
     background: none;
     color: var(--charles-blue);
-    font-weight: normal;
+    width: unset;
   }
 
   .access .menu > li > .btn:hover {

--- a/src/flavors/cycle3/static/css/custom.css
+++ b/src/flavors/cycle3/static/css/custom.css
@@ -1,6 +1,7 @@
 @import url('/static/css/city-wide-ext.css');
 @import url('/static/css/language-picker.css');
 @import url('/static/css/sidebar-collapse-ext.css');
+@import url('/static/css/list-view-mobile.css');
 
 /*
  * This CSS file follows the default Shareabouts style.css.
@@ -573,7 +574,7 @@ label {
   display: flex;
   gap: 0.5rem;
   align-items: center;
-}  
+}
 
 .place-private_submitter_race_ethnicity-field input {
   opacity: 1;
@@ -1384,9 +1385,9 @@ label {
    1px  1px 0 rgba(0,0,0,0.5);
 }
 
-.leaflet-tooltip.cluster-tooltip::before {                                                                 
-  display: none;                                                                                           
-}   
+.leaflet-tooltip.cluster-tooltip::before {
+  display: none;
+}
 
 .cluster-icon {
   width: 15px;

--- a/src/flavors/cycle3/static/css/custom.css
+++ b/src/flavors/cycle3/static/css/custom.css
@@ -1654,6 +1654,39 @@ label {
   ul.recent-points {
     /* border-left: 2px solid var(--optimistic-blue); */
   }
+
+  #site-header {
+    display: flex;
+    justify-content: left;
+  }
+
+  .has-pages #site-title{
+    height: 100%;
+    padding-left: 0;
+    flex-grow: 1;
+  }
+
+  .list-toggle-btn:hover {
+    color: var(--supporting-red-1);
+  }
+
+  .list-toggle-nav {
+    float: none;
+    display: flex;
+    align-items: center;
+    width: auto;
+    margin: 0;
+    margin-right: 9rem;
+    position: static;
+  }
+
+  #map-container, #content, #ticker, #list-container {
+    top: calc(var(--banner-height) + 2px);
+  }
+
+  .place-list-header {
+    max-width: none;
+  }
 }
 
 @media only screen and (width >= 1280px) {
@@ -1667,23 +1700,12 @@ label {
     --content-left-num: 0.45;
   }
 
-  #site-header {
-    display: flex;
-    justify-content: left;
-  }
-
   #site-header::before {
     content: none;
   }
 
   #site-header::after {
     content: none;
-  }
-
-  .has-pages #site-title{
-    height: 100%;
-    padding-left: 0;
-    flex-grow: 1;
   }
 
   #nav-btn {
@@ -1774,10 +1796,6 @@ label {
     min-width: 100%;
   }
 
-  .list-toggle-btn:hover {
-    color: var(--supporting-red-1);
-  }
-
   .menu-item-filter-type ul {
     width: 200%;
     transform: translateX(-25%);
@@ -1810,23 +1828,6 @@ label {
 
   .access li li .btn {
     margin: 0;
-  }
-
-  #map-container, #content, #ticker, #list-container {
-    top: calc(var(--banner-height) + 2px);
-  }
-
-  .place-list-header {
-    max-width: none;
-  }
-
-  .list-toggle-nav {
-    float: none;
-    display: flex;
-    align-items: center;
-    width: auto;
-    margin: 0;
-    position: static;
   }
 }
 

--- a/src/flavors/cycle3/static/css/custom.css
+++ b/src/flavors/cycle3/static/css/custom.css
@@ -2,6 +2,7 @@
 @import url('/static/css/language-picker.css');
 @import url('/static/css/sidebar-collapse-ext.css');
 @import url('/static/css/list-view-mobile.css');
+@import url('/static/css/map-view-mobile.css');
 
 /*
  * This CSS file follows the default Shareabouts style.css.

--- a/src/flavors/cycle3/static/css/images/show-list-icon.svg
+++ b/src/flavors/cycle3/static/css/images/show-list-icon.svg
@@ -27,7 +27,7 @@
      showgrid="false"
      inkscape:zoom="0.73704308"
      inkscape:cx="413.8157"
-     inkscape:cy="510.14657"
+     inkscape:cy="350.04738"
      inkscape:window-width="1704"
      inkscape:window-height="996"
      inkscape:window-x="0"
@@ -39,20 +39,20 @@
     <symbol
        id="g26933">
       <circle
-         style="fill:#000000;fill-opacity:1;stroke:none;stroke-width:3.175;stroke-linejoin:round;stroke-opacity:0.74902"
+         style="fill:#091424;fill-opacity:1;stroke:none;stroke-width:3.175;stroke-linejoin:round;stroke-opacity:0.74902"
          id="bullet01"
          cx="8"
          cy="8"
          r="8" />
       <rect
-         style="fill:#000000;fill-opacity:1;stroke:none;stroke-width:3.175;stroke-linejoin:round;stroke-opacity:0.74902"
+         style="fill:#091424;fill-opacity:1;stroke:none;stroke-width:3.175;stroke-linejoin:round;stroke-opacity:0.74902"
          id="rect01"
          width="60"
          height="12"
          x="30"
          y="0" />
       <rect
-         style="fill:#000000;fill-opacity:1;stroke:none;stroke-width:3.175;stroke-linejoin:round;stroke-opacity:0.74902"
+         style="fill:#091424;fill-opacity:1;stroke:none;stroke-width:3.175;stroke-linejoin:round;stroke-opacity:0.74902"
          id="rect02"
          width="40"
          height="12"

--- a/src/flavors/cycle3/static/css/images/show-list-icon.svg
+++ b/src/flavors/cycle3/static/css/images/show-list-icon.svg
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="90mm"
+   height="90mm"
+   viewBox="0 0 90 90"
+   version="1.1"
+   id="svg5"
+   inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
+   sodipodi:docname="show-list-icon.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <sodipodi:namedview
+     id="namedview7"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:document-units="mm"
+     showgrid="false"
+     inkscape:zoom="0.73704308"
+     inkscape:cx="413.8157"
+     inkscape:cy="510.14657"
+     inkscape:window-width="1704"
+     inkscape:window-height="996"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="layer1" />
+  <defs
+     id="defs2">
+    <symbol
+       id="g26933">
+      <circle
+         style="fill:#000000;fill-opacity:1;stroke:none;stroke-width:3.175;stroke-linejoin:round;stroke-opacity:0.74902"
+         id="bullet01"
+         cx="8"
+         cy="8"
+         r="8" />
+      <rect
+         style="fill:#000000;fill-opacity:1;stroke:none;stroke-width:3.175;stroke-linejoin:round;stroke-opacity:0.74902"
+         id="rect01"
+         width="60"
+         height="12"
+         x="30"
+         y="0" />
+      <rect
+         style="fill:#000000;fill-opacity:1;stroke:none;stroke-width:3.175;stroke-linejoin:round;stroke-opacity:0.74902"
+         id="rect02"
+         width="40"
+         height="12"
+         x="30"
+         y="22" />
+    </symbol>
+  </defs>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1">
+    <use
+       xlink:href="#g26933"
+       id="use26947" />
+    <use
+       xlink:href="#g26933"
+       id="use27026"
+       transform="translate(0,56)" />
+  </g>
+</svg>

--- a/src/flavors/cycle3/static/css/images/show-map-icon.svg
+++ b/src/flavors/cycle3/static/css/images/show-map-icon.svg
@@ -1,0 +1,1 @@
+<svg data-name="Layer 1" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 66 66"><path d="M49.09 27.83C49.09 36.72 33 54.27 33 54.27S16.91 36.72 16.91 27.83a16.09 16.09 0 0 1 32.19 0z" fill="none" stroke="#0d202e" stroke-miterlimit="10" stroke-width="3"/><circle cx="33.15" cy="25.86" r="5.92" fill="none" stroke="#0d202e" stroke-miterlimit="10" stroke-width="3"/></svg>

--- a/src/flavors/cycle3/static/css/images/show-map-icon.svg
+++ b/src/flavors/cycle3/static/css/images/show-map-icon.svg
@@ -1,1 +1,55 @@
-<svg data-name="Layer 1" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 66 66"><path d="M49.09 27.83C49.09 36.72 33 54.27 33 54.27S16.91 36.72 16.91 27.83a16.09 16.09 0 0 1 32.19 0z" fill="none" stroke="#0d202e" stroke-miterlimit="10" stroke-width="3"/><circle cx="33.15" cy="25.86" r="5.92" fill="none" stroke="#0d202e" stroke-miterlimit="10" stroke-width="3"/></svg>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   data-name="Layer 1"
+   viewBox="0 0 69.449554 90.480728"
+   version="1.1"
+   id="svg28232"
+   sodipodi:docname="show-map-icon.svg"
+   width="69.449554"
+   height="90.480728"
+   inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs28236" />
+  <sodipodi:namedview
+     id="namedview28234"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     showgrid="false"
+     inkscape:zoom="8.5999993"
+     inkscape:cx="34.593026"
+     inkscape:cy="44.883725"
+     inkscape:window-width="1704"
+     inkscape:window-height="996"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg28232" />
+  <path
+     d="M 61.449556,34.730934 C 61.449556,49.495652 34.724778,78.6431 34.724778,78.6431 34.724778,78.6431 8,49.495652 8,34.730934 8,19.967832 19.968809,8 34.733082,8 49.497357,8 61.449556,19.967832 61.449556,34.730934 Z"
+     fill="none"
+     stroke="#0d202e"
+     stroke-miterlimit="10"
+     stroke-width="3"
+     id="path28228"
+     style="stroke-width:16;stroke-dasharray:none;stroke:#091424;stroke-opacity:1"
+     sodipodi:nodetypes="ccsscc" />
+  <circle
+     cx="34.982151"
+     cy="31.0047"
+     r="16"
+     fill="none"
+     stroke="#0d202e"
+     stroke-miterlimit="10"
+     stroke-width="3"
+     id="circle28230"
+     style="stroke-width:8;stroke-dasharray:none;stroke:#091424;stroke-opacity:1" />
+</svg>

--- a/src/flavors/cycle3/static/css/list-view-mobile.css
+++ b/src/flavors/cycle3/static/css/list-view-mobile.css
@@ -143,4 +143,19 @@
     margin-left: 0;
     margin-right: 0;
   }
+
+  #list-container .iia-content-container {
+    background-image: none;
+    background-color: white;
+  }
+
+  #list-container .place-submission-details {
+    float: none;
+    width: auto;
+    text-align: center;
+  }
+
+  #list-container .place-submission-details .view-on-map-btn {
+    float: none;
+  }
 }

--- a/src/flavors/cycle3/static/css/list-view-mobile.css
+++ b/src/flavors/cycle3/static/css/list-view-mobile.css
@@ -157,7 +157,6 @@
   #list-container .place-submission-details {
     float: none;
     width: auto;
-    text-align: center;
   }
 
   #list-container .place-submission-details .view-on-map-btn {

--- a/src/flavors/cycle3/static/css/list-view-mobile.css
+++ b/src/flavors/cycle3/static/css/list-view-mobile.css
@@ -1,0 +1,146 @@
+/* =List View on Small Screens
+   Styles for the list view toggle and list container on screens
+   below 960px (the breakpoint where the default large-screen
+   styles kick in).
+-------------------------------------------------------------- */
+
+:root {
+  --leaflet-control-size: 33px;
+  --leaflet-control-edge-offset: 10px;
+  --leaflet-control-z-index: 1000;
+}
+
+@media only screen and (width < 960px) {
+
+  /* --- List/Map Toggle Button ---
+     Position the toggle like a Leaflet control on the map,
+     in the top-right of the map area, below the header.
+  */
+  #site-header .list-toggle-nav {
+    display: block;
+    position: absolute;
+    z-index: var(--leaflet-control-z-index);
+    top: calc(var(--pre-banner-height) + var(--banner-height) + var(--leaflet-control-edge-offset));
+    right: var(--leaflet-control-edge-offset);
+    float: none;
+    margin: 0;
+    padding: 0;
+  }
+
+  /* Style the toggle button to look like a Leaflet control */
+  #site-header .list-toggle-nav .list-toggle-btn,
+  #site-header .list-toggle-nav .list-toggle-btn:visited,
+  #site-header .list-toggle-nav .list-toggle-btn:link {
+    box-sizing: content-box;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 0;
+    margin: 0;
+    width: auto;
+    height: auto;
+    border: 2px solid rgb(0  0  0 / 20%);
+    border-radius: 4px;
+  }
+
+  #site-header .list-toggle-nav .list-toggle-btn:hover {
+    background-color: #f4f4f4;
+    color: var(--supporting-gray-4);
+  }
+
+  /* The show-the-list and show-the-map spans: override the
+     background-image icons to be smaller on the control button */
+  #site-header .list-toggle-nav .list-toggle-btn .show-the-list,
+  #site-header .list-toggle-nav .list-toggle-btn .show-the-map {
+    box-sizing: content-box;
+    padding-left: var(--leaflet-control-size);
+    width: 0;
+    height: var(--leaflet-control-size);
+    background-size: 18px 18px;
+    background-position: center center;
+    background-color: white;
+    overflow: hidden;
+  }
+
+  /* Push the locate-me control down so the list toggle button
+     sits above it. */
+  #map .leaflet-top.leaflet-right {
+    top: calc(var(--leaflet-control-size) + var(--leaflet-control-edge-offset));
+  }
+
+  /* At >= 480px, the pre-banner is hidden, so adjust the toggle
+     position accordingly. */
+  @media only screen and (width >= 480px) {
+    #site-header .list-toggle-nav {
+      top: calc(var(--banner-height) + var(--leaflet-control-edge-offset));
+    }
+  }
+
+
+  /* --- List Container ---
+     Full-screen overlay below the header, matching the
+     large-screen absolute-positioning approach.
+  */
+  #list-container.is-exposed {
+    display: block;
+    top: calc(var(--pre-banner-height) + var(--banner-height));
+    overflow: visible;
+  }
+
+  @media only screen and (width >= 480px) {
+    #list-container.is-exposed {
+      top: var(--banner-height);
+    }
+  }
+
+
+  /* --- List Header Layout ---
+     Search spans full width; filters stack below.
+     Right margin reserves space for the fixed toggle button.
+  */
+  #list-container .place-list-header {
+    flex-direction: column;
+    align-items: stretch;
+    padding: var(--leaflet-control-edge-offset);
+    padding-right: calc(var(--leaflet-control-size) + 2 * var(--leaflet-control-edge-offset) + 4px);  /* The extra 4px is for the map view button's border width */
+    box-sizing: border-box;
+  }
+
+  #list-container .list-search-form {
+    width: 100%;
+    display: flex;
+    gap: var(--leaflet-control-edge-offset);
+  }
+
+  #list-container .list-search-form input[type="text"] {
+    flex: 1;
+    box-sizing: content-box;
+    margin: 0;
+    padding: 0;
+    padding-left: var(--leaflet-control-edge-offset);
+    border-width: 2px;
+    border-radius: 4px;
+    height: var(--leaflet-control-size);
+    max-width: none;
+  }
+
+  #list-container .list-search-form input[type="submit"] {
+    box-sizing: content-box;
+    margin: 2px 0;
+    padding: 0 var(--leaflet-control-edge-offset);
+    border-radius: 2px;
+    height: var(--leaflet-control-size);
+  }
+
+  #list-container .list-filter-menu {
+    margin-top: 0.75rem;
+  }
+
+  /* --- Place List Items ---
+     Simplify the place list layout for narrow screens.
+  */
+  #list-container .place-list .place-items {
+    margin-left: 0;
+    margin-right: 0;
+  }
+}

--- a/src/flavors/cycle3/static/css/list-view-mobile.css
+++ b/src/flavors/cycle3/static/css/list-view-mobile.css
@@ -147,6 +147,11 @@
   #list-container .iia-content-container {
     background-image: none;
     background-color: white;
+    margin: 0 -1rem -2rem -1rem;
+  }
+
+  #list-container li:first-child .iia-content-container {
+    margin-top: -1rem;
   }
 
   #list-container .place-submission-details {

--- a/src/flavors/cycle3/static/css/map-view-mobile.css
+++ b/src/flavors/cycle3/static/css/map-view-mobile.css
@@ -1,0 +1,15 @@
+@media only screen and (width < 960px) {
+  #map {
+    /*
+      - The pre-banner is the area above the main header
+      - The banner is the main header
+      - The "Share an Idea" button area takes up about 4rem.
+      - The remaining 3rem is for the all ideas/city-wide ideas toggle, and a bit of the ideas list.
+    */
+    height: calc(90vh - var(--pre-banner-height) - var(--banner-height) - 4rem - 3rem);
+  }
+
+  body.content-visible #map {
+    height: 40vh;
+  }
+}

--- a/src/sa_web/templates/base.html
+++ b/src/sa_web/templates/base.html
@@ -134,8 +134,8 @@
   <script src="https://cdnjs.cloudflare.com/ajax/libs/perliedman-leaflet-control-geocoder/1.13.0/Control.Geocoder.js"></script>
 
   {% if uses_mapbox_layers %}
-  <link href="https://api.tiles.mapbox.com/mapbox-gl-js/v3.0.1/mapbox-gl.css" rel='stylesheet' />
-  <script src="https://api.tiles.mapbox.com/mapbox-gl-js/v3.0.1/mapbox-gl.js"></script>
+  <link href="https://api.tiles.mapbox.com/mapbox-gl-js/v3.24.0/mapbox-gl.css" rel='stylesheet' />
+  <script src="https://api.tiles.mapbox.com/mapbox-gl-js/v3.24.0/mapbox-gl.js"></script>
   <script src="https://unpkg.com/mapbox-gl-leaflet@0.0.16/leaflet-mapbox-gl.js"></script>
   {% endif %}
 
@@ -226,7 +226,7 @@
         S.bootstrapped.currentUser ?
         'user:' + S.bootstrapped.currentUser.id :
         {{ user_token_json|safe }}),
-      
+
       routePrefix: S.bootstrapped.routePrefix,
       apiPrefix: S.bootstrapped.apiPrefix,
 


### PR DESCRIPTION
This PR introduces a responsive list view for mobile devices

* Closes #86

### Key Changes

* Added `list-view-mobile.css` and `map-view-mobile.css` to handle responsive styling, including proper margins and borders for list items.
* Added new `show-list-icon.svg` and `show-map-icon.svg` icons for the toggle.
* Moved the list view button into the header on medium-sized screens for better accessibility and layout flow.
  * Before: <img width="1565" height="399" alt="image" src="https://github.com/user-attachments/assets/9bc606e0-bb8b-4fab-af6f-cdcad4ce08a9" />
  * After: <img width="1565" height="399" alt="image" src="https://github.com/user-attachments/assets/f10f27c9-0443-491e-a501-ce211607c152" />
* Gave more space to the map on mobile when the content area is closed (not directly related to the list view, but long as I was in there...).
* Updated to the latest version of `mapbox-gl.js` (also not directly related to list view, but was necessary for map styling updates) to keep map emphasis on user-generated content instead of base map content.
  * Before: <img width="1042" height="715" alt="image" src="https://github.com/user-attachments/assets/785f2c19-b1c3-436c-86af-8af8b4d02673" />
  * After: <img width="1042" height="715" alt="image" src="https://github.com/user-attachments/assets/20612b83-f8e5-4ffc-a80f-21637d1ea482" />

## How to Test
1. Open the application on a mobile device (or use responsive design mode in your browser's dev tools).
2. Look for the new toggle icons and verify you can switch between the Map and List views.
4. Switch back to the Map view and close the content area to ensure the map expands to fill the available space.
5. Resize the window to a medium screen width (tablet size) and verify the list view button appears correctly within the header.
