### PR TITLE
Fixes for the collapsible sidebar

### DIFF
--- a/src/flavors/cycle3/static/css/sidebar-collapse-ext.css
+++ b/src/flavors/cycle3/static/css/sidebar-collapse-ext.css
@@ -93,4 +93,15 @@
     left: calc(var(--content-left) + var(--ticker-width));
     right: 0;
   }
+
+  #colophon {
+    transition: right 0.3s ease;
+  }
+
+  body.sidebar-collapsed.activity-enabled.content-visible #colophon,
+  body.sidebar-collapsed.activity-enabled #colophon,
+  body.sidebar-collapsed.content-visible #colophon,
+  body.sidebar-collapsed #colophon {
+    right: 0;
+  }
 }

--- a/src/flavors/cycle3/static/css/sidebar-collapse-ext.css
+++ b/src/flavors/cycle3/static/css/sidebar-collapse-ext.css
@@ -59,6 +59,10 @@
     right: 0;
   }
 
+  body {
+    overflow-x: hidden;
+  }
+
   #ticker {
     transition: transform 0.3s ease;
   }

--- a/src/flavors/cycle3/static/css/sidebar-collapse-ext.css
+++ b/src/flavors/cycle3/static/css/sidebar-collapse-ext.css
@@ -21,7 +21,7 @@
     line-height: 1;
     padding: 0;
     box-shadow: -2px 0 5px rgba(0,0,0,0.2);
-    z-index: 1000;
+    z-index: 11;
     transition: right 0.3s ease;
   }
 


### PR DESCRIPTION
This PR introduces several styling fixes and adjustments to the collapsible sidebar functionality. 

* Adjusted the layout so the colophon takes up the full width of the screen when the sidebar is in its collapsed state.
* Restricted unintended horizontal scrolling when the sidebar is collapsed, preventing the content from extending past the viewport edges.
* Reduced the `z-index` of the `sidebar-toggle` element from `1000` to `11` to prevent it from incorrectly overlapping the list view.

## How to Test
1. Load the application and toggle the sidebar closed.
2. Verify that no horizontal scrollbar appears on the page.
3. Check the bottom of the screen to ensure the colophon now spans the entire width of the window.
4. Open the list view and verify that the sidebar toggle button does not inappropriately render on top of it

---

* Closes #92

