### PR TITLE
Center the idea legend header

### DIFF
--- a/src/flavors/cycle3/static/css/idea-legend-ext.css
+++ b/src/flavors/cycle3/static/css/idea-legend-ext.css
@@ -26,6 +26,7 @@
   display: flex;
   align-items: center;
   justify-content: center;
+  gap: 1rem;
   position: relative;
   width: 100%;
   padding: 0.75em 1em 0.5em;
@@ -39,12 +40,6 @@
 
 .legend-toggle:hover {
   background-color: var(--freedom-trail-red);
-}
-
-.legend-toggle-button {
-  position: absolute;
-  padding: 0.5rem;
-  right: 0;
 }
 
 .hamburger-icon {


### PR DESCRIPTION
Small aesthetic tweak to the idea legend header. @annaduan09 your call which you think is right.

Before the change:

<img width="913" height="196" alt="Screenshot from 2026-06-11 20-51-10" src="https://github.com/user-attachments/assets/f2b662fd-f4fe-4023-8311-e567816ef8c5" />
<img width="913" height="196" alt="Screenshot from 2026-06-11 20-51-03" src="https://github.com/user-attachments/assets/2f67a9ba-750a-4030-acdd-23eb80b91ca8" />

After the change:

<img width="913" height="196" alt="Screenshot from 2026-06-11 20-47-17" src="https://github.com/user-attachments/assets/23d3cd2c-0983-4d4b-84ad-d9f6fac5f385" />
<img width="913" height="196" alt="Screenshot from 2026-06-11 20-47-08" src="https://github.com/user-attachments/assets/8f87485c-3cc7-47ba-99d5-09a16771c077" />
