### PR TITLE
Truncate citywide idea language in submission form + city hall popup

### DIFF
--- a/src/flavors/cycle3/config.yml
+++ b/src/flavors/cycle3/config.yml
@@ -408,7 +408,7 @@ place:
 
   location_item_name: location
   city_wide_location_prompt: _(Citywide ideas apply to the entire City of Boston.)
-  city_wide_location_label: _(Multiple places throughout the city. Your idea will appear at City Hall.)
+  city_wide_location_label: _(Your idea will appear at City Hall.)
   city_wide_location_center:  [-71.05798753720381, 42.360394484137274]  # <- Boston City Hall (footprint centroid)
   city_wide_location_offset: 50  # Within 50 meters of City Hall
   unset_location_label: _(Please use the map's search box or drag the map to set the location.)

--- a/src/flavors/cycle3/jstemplates/city-hall-info.html
+++ b/src/flavors/cycle3/jstemplates/city-hall-info.html
@@ -4,6 +4,5 @@
 </div>
 <div class="city-hall-popup-body">
   <p>{{#_}}City-wide ideas apply to all of Boston, not a specific location or neighborhood.{{/_}}</p>
-  <p>{{#_}}On the map, these ideas appear in a ring around City Hall. You can click on them just like any other idea, or filter and read them-by-one using the sidebar or the scope dropdown in list view.{{/_}}</p>
-  <p>{{#_}}To share your own city-wide idea, click on "Share an idea", then click on the "City-wide" button.{{/_}}</p>
+  <p>{{#_}}On the map, these ideas appear in a ring around City Hall.{{/_}}</p>
 </div>


### PR DESCRIPTION
Shorten the language in the idea submission form and the City Hall popup