### PR TITLE
99 reduce the number of boston brand colors

### DIFF
--- a/src/flavors/cycle3/static/css/custom.css
+++ b/src/flavors/cycle3/static/css/custom.css
@@ -244,7 +244,7 @@ a.close-btn {
 .btn-primary,
 .btn-primary:visited,
 .btn-primary:link {
-  background-color: var(--supporting-red-1);
+  background-color: var(--content-link-hover);
 }
 
 .btn:hover {
@@ -280,10 +280,6 @@ a.close-btn {
   color: var(--attention-fg);
   font-weight: bold;
 }
-
-/* .btn-primary, .btn-primary:visited, .btn-primary:link {
-  font-size: 1rem;
-} */
 
 /* =Header
 -------------------------------------------------------------- */
@@ -429,7 +425,7 @@ a.close-btn {
   align-items: center;
   justify-content: center;
   padding: 0;
-  background: var(--supporting-red-1);
+  background: var(--iia-urban-pink);
 
   font-size: 3rem;
   color: white;
@@ -1272,7 +1268,7 @@ body[data-city_wide="true"] .location-field-label .regular-prompt { display: non
 }
 
 #show-language-picker-btn:hover {
-  color: var(--supporting-red-1);
+  color: var(--content-link-hover);
 }
 
 @media only screen and (width >=48rem) {
@@ -1458,7 +1454,7 @@ body[data-city_wide="true"] .location-field-label .regular-prompt { display: non
 .list-filter-menu a:hover,
 .list-sort-menu select:hover,
 .list-filter-menu select:hover {
-  color: var(--supporting-red-1);
+  color: var(--content-link-hover);
   cursor: pointer;
 }
 
@@ -1934,7 +1930,7 @@ body[data-city_wide="true"] .location-field-label .regular-prompt { display: non
   }
 
   .list-toggle-btn:hover {
-    color: var(--supporting-red-1);
+    color: var(--content-link-hover);
   }
 
   .list-toggle-nav {
@@ -2047,7 +2043,7 @@ body[data-city_wide="true"] .location-field-label .regular-prompt { display: non
   }
 
   .access .menu>li>.btn:hover {
-    color: var(--supporting-red-1);
+    color: var(--content-link-hover);
   }
 
   .access li:hover>ul,

--- a/src/flavors/cycle3/static/css/custom.css
+++ b/src/flavors/cycle3/static/css/custom.css
@@ -105,7 +105,7 @@
 
 body {
   font-family: var(--body-font);
-  color: var(--charles-blue);
+  color: var(--iia-dark-blue);
   background-color: var(--iia-fog-grey);
 }
 
@@ -223,7 +223,7 @@ a.close-btn {
 }
 
 #add-place-btn-container {
-  background-color: var(--charles-blue);
+  background-color: var(--iia-dark-blue);
 }
 
 .btn,
@@ -248,7 +248,7 @@ a.close-btn {
 }
 
 .btn:hover {
-  background-color: var(--freedom-trail-red);
+  background-color: var(--content-link);
 }
 
 .btn-small:visited,
@@ -289,7 +289,7 @@ a.close-btn {
   left: 0;
   width: 100%;
   height: var(--pre-banner-height);
-  background-color: var(--charles-blue);
+  background-color: var(--iia-dark-blue);
   color: white;
   font-family: var(--header-font);
   font-size: 0.9rem;
@@ -336,7 +336,7 @@ a.close-btn {
   float: none;
   margin-right: 9rem;
   font-family: var(--header-font);
-  color: var(--charles-blue);
+  color: var(--iia-dark-blue);
   text-shadow: none;
 }
 
@@ -350,7 +350,7 @@ a.close-btn {
   float: none;
   margin: 0.5rem -0.5rem;
   width: calc(100% + 1rem);
-  background-color: var(--charles-blue);
+  background-color: var(--iia-dark-blue);
 }
 
 .access .btn {
@@ -383,7 +383,7 @@ a.close-btn {
   display: flex;
   align-items: center;
   font-size: 1rem;
-  color: var(--charles-blue);
+  color: var(--iia-dark-blue);
 }
 
 #site-title .boston-icon {
@@ -396,7 +396,7 @@ a.close-btn {
   margin: -0.5rem 0.5rem -0.5rem -0.5rem;
   padding:
     calc(var(--banner-height) / 2 - var(--icon-height) / 2) calc(var(--banner-height) / 2 - var(--icon-height) * var(--aspect-ratio) / 2);
-  background-color: var(--charles-blue);
+  background-color: var(--iia-dark-blue);
 }
 
 #site-title .pb-icon {
@@ -512,8 +512,8 @@ body .select2-container--default .select2-selection--single {
   padding: 0.5em;
   border-width: 0.25em;
   border-radius: 0;
-  border-color: var(--charles-blue);
-  color: var(--charles-blue);
+  border-color: var(--iia-dark-blue);
+  color: var(--iia-dark-blue);
   font-family: var(--body-font);
   font-weight: normal;
   text-transform: none;
@@ -559,8 +559,8 @@ label {
 :focus+.checkbox-label-text,
 .checkbox-label-text:hover {
   background-color: var(--supporting-gray-4);
-  color: var(--charles-blue);
-  border-color: var(--charles-blue);
+  color: var(--iia-dark-blue);
+  border-color: var(--iia-dark-blue);
   cursor: pointer;
 }
 
@@ -716,8 +716,8 @@ body[data-city_wide="true"] .location-field-label .regular-prompt { display: non
 
 [name="location_type"]+.label-text:hover {
   background-color: var(--supporting-gray-4);
-  border-color: var(--charles-blue);
-  color: var(--charles-blue);
+  border-color: var(--iia-dark-blue);
+  color: var(--iia-dark-blue);
 }
 
 [name="location_type"][value="arts_culture"]+.label-text:hover {
@@ -816,7 +816,7 @@ body[data-city_wide="true"] .location-field-label .regular-prompt { display: non
   background-color: var(--icon-color-07);
   background-image: url("/static/img/categories/human_services-dark-square.svg");
   border-color: var(--icon-color-07);
-  color: var(--charles-blue);
+  color: var(--iia-dark-blue);
 }
 
 [name="location_type"][value="public_safety"]:checked+.label-text {
@@ -837,7 +837,7 @@ body[data-city_wide="true"] .location-field-label .regular-prompt { display: non
   background-color: var(--icon-color-10);
   background-image: url("/static/img/categories/other-dark-square.svg");
   border-color: var(--icon-color-10);
-  color: var(--charles-blue);
+  color: var(--iia-dark-blue);
 }
 
 .fullname-field-wrapper {
@@ -1010,7 +1010,7 @@ body[data-city_wide="true"] .location-field-label .regular-prompt { display: non
   width: 100%;
   margin: 0.5rem 0;
   box-sizing: border-box;
-  border: 1px solid var(--charles-blue);
+  border: 1px solid var(--iia-dark-blue);
   box-shadow: 2px 2px 2px rgba(0, 0, 0, 0.5);
 }
 
@@ -1123,29 +1123,25 @@ body[data-city_wide="true"] .location-field-label .regular-prompt { display: non
   width: 100%;
   height: 100%;
   background-color: white;
-  color: var(--charles-blue);
+  color: var(--iia-dark-blue);
   font-weight: normal;
   text-align: center;
   border: 2px solid transparent;
-  /* border-bottom-color: var(--optimistic-blue) */
 }
 
 .activity-filters .display-choice label:hover {
   cursor: pointer;
-  color: var(--freedom-trail-red);
+  color: var(--content-link-hover);
   border-style: dashed;
-  border-color: var(--freedom-trail-red);
+  border-color: var(--content-link-hover);
 }
 
 .activity-filters .display-choice input[type="radio"]:checked+label {
-  background-color: var(--charles-blue);
+  background-color: var(--iia-dark-blue);
   color: white;
   font-weight: bold;
   text-decoration: underline;
   border-color: transparent;
-  /* border-top-color: var(--optimistic-blue);
-  border-right-color: var(--optimistic-blue);
-  border-left-color: var(--optimistic-blue); */
   border-style: solid;
   cursor: default;
 }
@@ -1257,7 +1253,7 @@ body[data-city_wide="true"] .location-field-label .regular-prompt { display: non
   background-color: transparent;
   background-size: 1.5rem;
   background-position: right center;
-  color: var(--charles-blue);
+  color: var(--iia-dark-blue);
   font-weight: normal;
 }
 
@@ -1307,7 +1303,7 @@ body[data-city_wide="true"] .location-field-label .regular-prompt { display: non
     background-size: 1.5rem;
     background-repeat: no-repeat;
     background-position: left center;
-    color: var(--charles-blue);
+    color: var(--iia-dark-blue);
     font-weight: normal;
   }
 
@@ -1332,7 +1328,7 @@ body[data-city_wide="true"] .location-field-label .regular-prompt { display: non
   background-color: transparent;
   border: none;
   box-shadow: none;
-  color: var(--charles-blue);
+  color: var(--iia-dark-blue);
   font-weight: normal;
 }
 
@@ -1355,7 +1351,7 @@ body[data-city_wide="true"] .location-field-label .regular-prompt { display: non
 }
 
 .place-list-header {
-  background-color: var(--charles-blue);
+  background-color: var(--iia-dark-blue);
   display: flex;
   align-items: center;
   justify-content: space-between;
@@ -1396,7 +1392,7 @@ body[data-city_wide="true"] .location-field-label .regular-prompt { display: non
   padding: 0;
   border: none;
   border-bottom: 1px solid currentColor;
-  background-color: var(--charles-blue);
+  background-color: var(--iia-dark-blue);
   text-transform: inherit;
   text-overflow: ellipsis;
   margin-right: 1em;
@@ -1483,7 +1479,7 @@ body[data-city_wide="true"] .location-field-label .regular-prompt { display: non
   z-index: 1000;
   width: 250px;
   background-color: var(--iia-fog-grey);
-  color: var(--charles-blue);
+  color: var(--iia-dark-blue);
   font-family: var(--header-font);
   font-size: 0.8em;
   border-radius: 0.5rem;
@@ -1830,12 +1826,12 @@ body[data-city_wide="true"] .location-field-label .regular-prompt { display: non
   }
 
   .menu {
-    border: 2px solid var(--charles-blue);
+    border: 2px solid var(--iia-dark-blue);
     min-width: 20rem;
   }
 
   .menu-item {
-    border-bottom: 2px solid var(--charles-blue);
+    border-bottom: 2px solid var(--iia-dark-blue);
   }
 
   .menu-item:last-child {
@@ -1870,7 +1866,7 @@ body[data-city_wide="true"] .location-field-label .regular-prompt { display: non
   .access li:hover>ul,
   .access li:hover>form>ul {
     display: block;
-    background: var(--charles-blue);
+    background: var(--iia-dark-blue);
     box-shadow: none;
     border: none;
     border-radius: 0;
@@ -1890,7 +1886,7 @@ body[data-city_wide="true"] .location-field-label .regular-prompt { display: non
   }
 
   .access li li .btn:hover {
-    background-color: var(--freedom-trail-red);
+    background-color: var(--content-link-hover);
   }
 }
 
@@ -1912,10 +1908,6 @@ body[data-city_wide="true"] .location-field-label .regular-prompt { display: non
   a.close-btn {
     box-shadow:
       calc(var(--shadow-offset) * -1) var(--shadow-offset) var(--shadow-blur) var(--shadow-spread) var(--shadow-color);
-  }
-
-  ul.recent-points {
-    /* border-left: 2px solid var(--optimistic-blue); */
   }
 
   #site-header {
@@ -2037,7 +2029,7 @@ body[data-city_wide="true"] .location-field-label .regular-prompt { display: non
     padding: 0;
     margin-left: 1.25rem;
     background: none;
-    color: var(--charles-blue);
+    color: var(--iia-dark-blue);
     font-weight: normal;
     width: unset;
   }
@@ -2052,7 +2044,7 @@ body[data-city_wide="true"] .location-field-label .regular-prompt { display: non
     left: 1.25rem;
     border: none;
     box-shadow: none;
-    background-color: var(--charles-blue);
+    background-color: var(--iia-dark-blue);
     top: 215%;
   }
 

--- a/src/flavors/cycle3/static/css/custom.css
+++ b/src/flavors/cycle3/static/css/custom.css
@@ -81,7 +81,7 @@
   --attention-bg: var(--iia-callout-blue);
   --attention-fg: white;
 
-  --selection-bg: var(--iia-electric-purple-alt);
+  --selection-bg: var(--iia-callout-blue);
   --selection-fg: white;
 
   --map-bg: var(--iia-dark-blue);
@@ -2114,7 +2114,7 @@ body[data-city_wide="true"] .location-field-label .regular-prompt { display: non
     --content-link: var(--iia-electric-purple);
     --content-link-hover: var(--iia-urban-pink);
 
-    --selection-bg: var(--iia-electric-purple);
+    --selection-bg: var(--iia-callout-blue);
 
     --map-bg: var(--iia-fog-grey);
   }

--- a/src/flavors/cycle3/static/css/custom.css
+++ b/src/flavors/cycle3/static/css/custom.css
@@ -342,8 +342,6 @@ a.close-btn {
 
 .menu .btn-block {
   padding: 1.275em 1.5em;
-  background-color: var(--supporting-blue-5);
-  color: white;
 }
 
 .access {
@@ -2066,7 +2064,7 @@ body[data-city_wide="true"] .location-field-label .regular-prompt { display: non
     padding-bottom: 0.75rem;
   }
 
-  #current-filter-type {
+/*   #current-filter-type {
     position: absolute;
     width: 250%;
     transform: translateX(-30%);
@@ -2076,7 +2074,7 @@ body[data-city_wide="true"] .location-field-label .regular-prompt { display: non
     font-weight: normal;
     font-style: italic;
     color: var(--supporting-blue-3);
-  }
+  } */
 
   .access li li {
     padding: 0 2px 2px 2px;

--- a/src/flavors/cycle3/static/css/idea-legend-ext.css
+++ b/src/flavors/cycle3/static/css/idea-legend-ext.css
@@ -8,6 +8,7 @@
   font-size: 0.875em;
   --selection-bg: var(--iia-callout-blue);
   padding: 0.5em 0.5em 0.75em;
+  background-color: var(--iia-dark-blue);
 }
 
 .content-visible .legend-wrapper {

--- a/src/flavors/cycle3/static/css/idea-legend-ext.css
+++ b/src/flavors/cycle3/static/css/idea-legend-ext.css
@@ -6,8 +6,7 @@
   width: 100%;
   box-sizing: border-box;
   font-size: 0.875em;
-  --selection-bg: var(--supporting-red-1);
-  background-color: var(--charles-blue);
+  --selection-bg: var(--iia-callout-blue);
   padding: 0.5em 0.5em 0.75em;
 }
 
@@ -31,7 +30,6 @@
   width: 100%;
   padding: 0.75em 1em 0.5em;
   font-size: 1.25em;
-  background-color: var(--supporting-red-1);
   color: white;
   border: none;
   cursor: pointer;
@@ -39,7 +37,7 @@
 }
 
 .legend-toggle:hover {
-  background-color: var(--freedom-trail-red);
+  background-color: var(--iia-indigo-blue);
 }
 
 .hamburger-icon {
@@ -84,7 +82,7 @@
   max-height: 0;
   overflow: hidden;
   transition: max-height 0.3s ease;
-  color: var(--charles-blue);
+  color: var(--iia-dark-blue);
 }
 
 .open .place-type-legend {
@@ -108,7 +106,7 @@
   padding: 0.5rem;
   border: none;
   text-decoration: none;
-  color: var(--charles-blue);
+  color: var(--iia-dark-blue);
   background-color: var(--iia-fog-grey);
 }
 
@@ -174,7 +172,7 @@
   }
 
   .legend-toggle {
-    background-color: var(--charles-blue);
+    background-color: var(--iia-dark-blue);
     font-size: 1em;
     padding: 0.5rem;
   }

--- a/src/flavors/cycle3/static/css/idea-legend-ext.css
+++ b/src/flavors/cycle3/static/css/idea-legend-ext.css
@@ -7,7 +7,7 @@
   box-sizing: border-box;
   font-size: 0.875em;
   --selection-bg: var(--iia-callout-blue);
-  padding: 0.5em 0.5em 0.75em;
+  padding: 0.5em 0.5em;
   background-color: var(--iia-dark-blue);
 }
 


### PR DESCRIPTION
This pull request replaces City of Boston colors with Ideas in Action (IIA) colors. Where possible, similar IIA colors were selected (for example, charles-blue to iia-dark-blue). The most noticeable changes:
- “Share an Idea” buttons were changed from `--freedom-trail-red` to `--content-link-hover` (`--iia-urban-pink` in light mode, `--iia-urban-pink-alt` in dark). 
- menu urls are now `--iia-urban-pink` when hovered instead of `--freedom-trail-red` for consistency.
- ticker items (via `--selection-bg)` are now `--iia-callout-blue` instead of `--iia-electric-purple` when hovered to reduce contrast.

### Before
<img width="1406" height="696" alt="Screenshot 2026-06-22 at 3 53 46 PM" src="https://github.com/user-attachments/assets/d84e18bd-b713-4699-9ae6-8d602c33689c" />

### After
<img width="1404" height="695" alt="Screenshot 2026-06-22 at 3 54 39 PM" src="https://github.com/user-attachments/assets/9eecc7fd-aa64-447f-8a20-880785b41a32" />

