### PR TITLE
Adjust the data load progress bar so that it doesn't overlap with other elements

### DIFF
--- a/src/flavors/cycle3/static/css/custom.css
+++ b/src/flavors/cycle3/static/css/custom.css
@@ -210,6 +210,22 @@ a.close-btn {
   background-color: var(--map-bg);
 }
 
+#map-progress {
+  top: 57px;
+}
+
+@media only screen and (width >= 60rem) {
+  body.content-visible.activity-enabled #map-progress {
+    right: calc(70% - var(--ticker-width) * .1);
+  }
+}
+
+@media only screen and (width >= 80rem) {
+  body.content-visible.activity-enabled #map-progress {
+    right: calc(55% - var(--ticker-width) * .2);
+  }
+}
+
 .leaflet-light-pane {
   display: block;
 }


### PR DESCRIPTION
When the page first loads, the progress bar shouldn't overlap with the address search bar or the content panel. In some exceptional cases, the search bar may take up twice its own height, and in those cases the progress bar will overlap, but that should not be normal.

Resolves #104 