### PR TITLE
Update demographic form checkbox labels to be left-aligned

### DIFF
--- a/src/flavors/cycle3/static/css/custom.css
+++ b/src/flavors/cycle3/static/css/custom.css
@@ -617,6 +617,7 @@ label {
   display: block;
   padding: 0.5rem 0;
   border: none;
+  text-align: left;
   font-size: 1rem;
 }
 


### PR DESCRIPTION
Before:
<img width="1962" height="1069" alt="image" src="https://github.com/user-attachments/assets/60f055cb-abd7-438c-8e98-49db582d167a" />

After:
<img width="1962" height="1069" alt="image" src="https://github.com/user-attachments/assets/7062f9fd-8ae7-42d6-afea-f2547772b5de" />

---
Resolves #122