### PR TITLE
Make the out-of-bounds idea warning message consistent

### DIFF
--- a/src/flavors/cycle3/jstemplates/place-form.html
+++ b/src/flavors/cycle3/jstemplates/place-form.html
@@ -1,6 +1,7 @@
       <div class="iia-content-container">
         <p class="drag-marker-instructions">{{ place_config.unset_location_label }}</p>
         <p class="drag-marker-warning is-visuallyhidden">{{#_}}It looks like you didn't set your location yet.{{/_}} {{ place_config.unset_location_label }}</p>
+        <p class="out-of-bounds-warning is-visuallyhidden">{{> place-form-out-of-bounds-message }}</p>
 
         <!-- <h4 class="">{{ place_config.title }}</h4> -->
         <h4>{{#_}}How would <img class="inline-scribble" src="/static/img/iia/Scribble_Wavey_04_Pink.svg"> you spend <span class="bigger-text"><span class="scribble-text scribble-text-pink">$</span><span class="scribble-underline">2 million</span></span> to <img class="inline-scribble" src="/static/img/iia/Scribble_Arrow_02_Pink.svg" alt=""> benefit our <span class="bigger-text">communities<span class="scribble-text scribble-text-pink">?</span></span>{{/_}}</h4>

--- a/src/flavors/cycle3/static/css/custom.css
+++ b/src/flavors/cycle3/static/css/custom.css
@@ -888,9 +888,23 @@ body[data-city_wide="true"] .location-field-label .regular-prompt { display: non
   font-style: italic;
 }
 
+.drag-marker-warning,
+.out-of-bounds-warning,
 .drag-marker-instructions {
   background-color: var(--instructions-bg);
   color: var(--instructions-fg);
+
+  font-weight: bold;
+  text-shadow: none;
+  text-align: center;
+  margin-bottom: 1em;
+  padding: 0.75em 1em 0.875em;
+  border-radius: 0.325em;
+}
+
+.drag-marker-warning,
+.out-of-bounds-warning {
+  text-decoration: underline;
 }
 
 .awaiting-location {

--- a/src/flavors/cycle3/static/js/place-form-view-city-boundary-ext.js
+++ b/src/flavors/cycle3/static/js/place-form-view-city-boundary-ext.js
@@ -16,13 +16,17 @@ compares the currently-selected location to those boundaries using turf.js. */
     // Make sure that the center point has been set after the form was
     // rendered. If not, this is a good indication that the user neglected
     // to move the map to set it in the correct location.
-    this.$('.drag-marker-instructions').addClass('is-visuallyhidden');
-    this.$('.out-of-bounds-warning').removeClass('is-visuallyhidden');
+    this.el.querySelector('.drag-marker-instructions').classList.add('is-visuallyhidden');
 
-    // Scroll to the top of the panel if desktop
-    this.$el.parent('article').scrollTop(0);
-    // Scroll to the top of the window, if mobile
-    window.scrollTo(0, 0);
+    const warningEl = this.el.querySelector('.out-of-bounds-warning')
+    warningEl.classList.remove('is-visuallyhidden');
+
+    // Scroll to the top of the form if desktop
+    warningEl.scrollIntoView({behavior: 'smooth', block: 'start'});
+
+    // For good measure, ensure that the map is visible as well. Useful
+    // for mobile, where the map maybe above the form.
+    window.app.appView.mapView.el.scrollIntoView({behavior: 'smooth', block: 'start'});
   };
 
   const Shareabouts_PlaceFormView_setLocation = Shareabouts.PlaceFormView.prototype.setLocation;
@@ -51,7 +55,7 @@ compares the currently-selected location to those boundaries using turf.js. */
   const Shareabouts_PlaceFormView_setLatLng = Shareabouts.PlaceFormView.prototype.setLatLng;
   Shareabouts.PlaceFormView.prototype.setLatLng = function(latLng) {
     Shareabouts_PlaceFormView_setLatLng.call(this, latLng);
-    this.$('.out-of-bounds-warning').addClass('is-visuallyhidden');
+    this.el.querySelector('.out-of-bounds-warning').classList.add('is-visuallyhidden');
   }
 
   const Shareabouts_PlaceFormView_onSubmit = Shareabouts.PlaceFormView.prototype.onSubmit;

--- a/src/flavors/cycle3/static/js/place-form-view-city-boundary-ext.js
+++ b/src/flavors/cycle3/static/js/place-form-view-city-boundary-ext.js
@@ -6,6 +6,12 @@ compares the currently-selected location to those boundaries using turf.js. */
 (function() {
   'use strict';
 
+  const Shareabouts_PlaceFormView_initialize = Shareabouts.PlaceFormView.prototype.initialize;
+  Shareabouts.PlaceFormView.prototype.initialize = function(options) {
+    Shareabouts_PlaceFormView_initialize.call(this, options);
+    this.isOutOfBounds = false;
+  };
+      
   Shareabouts.PlaceFormView.prototype.showOutOfBoundsWarning = function() {
     // Make sure that the center point has been set after the form was
     // rendered. If not, this is a good indication that the user neglected
@@ -19,12 +25,6 @@ compares the currently-selected location to those boundaries using turf.js. */
     window.scrollTo(0, 0);
   };
 
-  const Shareabouts_PlaceFormView_initialize = Shareabouts.PlaceFormView.prototype.initialize;
-  Shareabouts.PlaceFormView.prototype.initialize = function(options) {
-    Shareabouts_PlaceFormView_initialize.call(this, options);
-    this.isOutOfBounds = false;
-  };
-      
   const Shareabouts_PlaceFormView_setLocation = Shareabouts.PlaceFormView.prototype.setLocation;
   Shareabouts.PlaceFormView.prototype.setLocation = function(location) {
     // Check whether the current center point is within the city boundaries. If

--- a/src/flavors/cycle3/static/js/place-form-view-city-boundary-ext.js
+++ b/src/flavors/cycle3/static/js/place-form-view-city-boundary-ext.js
@@ -11,12 +11,18 @@ compares the currently-selected location to those boundaries using turf.js. */
     // rendered. If not, this is a good indication that the user neglected
     // to move the map to set it in the correct location.
     this.$('.drag-marker-instructions').addClass('is-visuallyhidden');
-    this.$('.drag-marker-warning').removeClass('is-visuallyhidden');
+    this.$('.out-of-bounds-warning').removeClass('is-visuallyhidden');
 
     // Scroll to the top of the panel if desktop
     this.$el.parent('article').scrollTop(0);
     // Scroll to the top of the window, if mobile
     window.scrollTo(0, 0);
+  };
+
+  const Shareabouts_PlaceFormView_initialize = Shareabouts.PlaceFormView.prototype.initialize;
+  Shareabouts.PlaceFormView.prototype.initialize = function(options) {
+    Shareabouts_PlaceFormView_initialize.call(this, options);
+    this.isOutOfBounds = false;
   };
       
   const Shareabouts_PlaceFormView_setLocation = Shareabouts.PlaceFormView.prototype.setLocation;
@@ -32,19 +38,25 @@ compares the currently-selected location to those boundaries using turf.js. */
     locationReceiver.classList.toggle('is-invalid', !isWithinCityBoundaries);
 
     if (isWithinCityBoundaries) {
-      this.isLocationValid = true;
+      this.isOutOfBounds = false;
       Shareabouts_PlaceFormView_setLocation.call(this, location);
     } else {
-      this.isLocationValid = false;
+      this.isOutOfBounds = true;
       this.location = null;
       locationReceiver.classList.add('awaiting-location');
       locationReceiver.innerHTML = Handlebars.templates['place-form-out-of-bounds-message']();
     }
   }
 
+  const Shareabouts_PlaceFormView_setLatLng = Shareabouts.PlaceFormView.prototype.setLatLng;
+  Shareabouts.PlaceFormView.prototype.setLatLng = function(latLng) {
+    Shareabouts_PlaceFormView_setLatLng.call(this, latLng);
+    this.$('.out-of-bounds-warning').addClass('is-visuallyhidden');
+  }
+
   const Shareabouts_PlaceFormView_onSubmit = Shareabouts.PlaceFormView.prototype.onSubmit;
   Shareabouts.PlaceFormView.prototype.onSubmit = function(evt) {
-    if (this.isLocationValid) {
+    if (!this.isOutOfBounds) {
       return Shareabouts_PlaceFormView_onSubmit.call(this, evt);
     } else {
       evt.preventDefault();


### PR DESCRIPTION
Instead of using the same `It looks like you didn't set your location yet...` message that comes up when a user submits their idea before moving the map, I added a new element that contains the `Ideas for locations outside of the limits of the City of Boston...` message. When a user submits an idea with the marker outside of the city they are presented with that element.

I also changed the text style in the warnings to make it consistent with the rest of the page while still standing out.

---

Resolves #111 