### PR TITLE
Add --hover-bg color to differentiate from --selection-bg

### DIFF
--- a/src/flavors/cycle3/static/css/custom.css
+++ b/src/flavors/cycle3/static/css/custom.css
@@ -81,8 +81,10 @@
   --attention-bg: var(--iia-callout-blue);
   --attention-fg: white;
 
-  --selection-bg: var(--iia-callout-blue);
+  --selection-bg: var(--iia-electric-purple-alt);
   --selection-fg: white;
+
+  --hover-bg: var(--iia-callout-blue);
 
   --map-bg: var(--iia-dark-blue);
 
@@ -1093,9 +1095,9 @@ body[data-city_wide="true"] .location-field-label .regular-prompt { display: non
 }
 
 .recent-points a:hover {
-  color: var(--selection-fg);
-  background: var(--selection-bg);
-  border-color: var(--selection-bg);
+  color: var(--hover-fg);
+  background: var(--hover-bg);
+  border-color: var(--hover-bg);
 }
 
 .recent-points .avatar {
@@ -2169,7 +2171,7 @@ body[data-city_wide="true"] .location-field-label .regular-prompt { display: non
     --content-link: var(--iia-electric-purple);
     --content-link-hover: var(--iia-urban-pink);
 
-    --selection-bg: var(--iia-callout-blue);
+    --selection-bg: var(--iia-electric-purple);
 
     --map-bg: var(--iia-fog-grey);
   }


### PR DESCRIPTION
While resolving #99, changing the hover color of the ticker items (`.recent-points a:hover`) from `iia-electric-purple` to `iia-callout-blue` had the unintended effect of making the idea submission form's buttons and Boston boundary overlay blue as well. This PR adds a `--hover-bg` variable to separate the ticker hover color from the selection color used in the idea submission form.

