### PR TITLE
Fix category hover instructions covering the category buttons

### DIFF
--- a/src/flavors/cycle3/static/css/custom.css
+++ b/src/flavors/cycle3/static/css/custom.css
@@ -979,9 +979,7 @@ body[data-city_wide="true"] .location-field-label .regular-prompt { display: non
 }
 
 .place-location_type-option-description {
-  position: sticky;
-  top: calc(var(--pre-banner-height) + 1rem);
-  z-index: 10000;
+  position: static;
   background-color: var(--attention-bg);
   color: var(--attention-fg);
 }

--- a/src/flavors/cycle3/static/css/custom.css
+++ b/src/flavors/cycle3/static/css/custom.css
@@ -986,6 +986,15 @@ body[data-city_wide="true"] .location-field-label .regular-prompt { display: non
   color: var(--attention-fg);
 }
 
+@media only screen and (width >= 60rem) {
+    /* 960px */
+    .place-location_type-option-description {
+      position: static;
+      top: unset;
+      z-index: unset;
+    }
+  }
+
 @media (hover: hover) and (width >=1024px) {
   .hidden-if-no-hover {
     display: revert;

--- a/src/flavors/cycle3/static/css/custom.css
+++ b/src/flavors/cycle3/static/css/custom.css
@@ -979,7 +979,9 @@ body[data-city_wide="true"] .location-field-label .regular-prompt { display: non
 }
 
 .place-location_type-option-description {
-  position: static;
+  position: sticky;
+  top: calc(var(--pre-banner-height) + 1rem);
+  z-index: 10000;
   background-color: var(--attention-bg);
   color: var(--attention-fg);
 }


### PR DESCRIPTION
`.place-location_type-option-description` was `position: sticky`. Combined with `#content` also being sticky, the category instructions text appeared pinned to the screen while scrolling instead of moving with the page, covering the category buttons. 

Changing it to `position: static` so it scrolls with the rest of the form.

**Before**
<img width="510" height="653" alt="Screenshot 2026-07-08 at 4 17 31 PM" src="https://github.com/user-attachments/assets/54d16943-6ebe-467c-8ee1-8b6ab02e49bd" />

**After**
<img width="518" height="623" alt="Screenshot 2026-07-08 at 4 17 17 PM" src="https://github.com/user-attachments/assets/7c41a8d3-1b3e-46e8-bfad-5034eab1ebac" />

Closes #140 