### PR TITLE
Add initial templates and routes for sa_vote app

### DIFF
--- a/src/project/settings.py
+++ b/src/project/settings.py
@@ -193,6 +193,7 @@ INSTALLED_APPS = (
 
     # Instance-specific app
     'pbboston',
+    'sa_vote',
 
     # Project apps
     'sa_web',

--- a/src/project/urls.py
+++ b/src/project/urls.py
@@ -22,6 +22,7 @@ urlpatterns = staticfiles_urlpatterns() + [
     path(base_path + 'users/begin/<provider>', auth_views.oauth_begin, name='oauth_begin'),
     path(base_path + 'users/complete/<provider>', auth_views.oauth_complete, name='oauth_complete'),
     path(base_path + 'admin/', include('sa_admin.urls')),
+    path(base_path + 'vote', include('sa_vote.urls')),
     path(base_path + '', include('sa_web.urls')),
 ]
 

--- a/src/sa_vote/ballots.py
+++ b/src/sa_vote/ballots.py
@@ -1,0 +1,8 @@
+"""
+Ballots module for Shareabouts Vote App
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Contains code for managing ballots, including loading ballot proposal
+information from Markdown and YAML files, and modifying ballot proposals in the
+repository.
+"""

--- a/src/sa_vote/static/sa_vote/main.js
+++ b/src/sa_vote/static/sa_vote/main.js
@@ -1,0 +1,3 @@
+import { Router } from './routes.js';
+
+window.app = new Router();

--- a/src/sa_vote/static/sa_vote/routes.js
+++ b/src/sa_vote/static/sa_vote/routes.js
@@ -1,0 +1,24 @@
+const Router = Backbone.Router.extend({
+  routes: {
+    '': 'homeRoute',
+    'faq': 'faqRoute',
+  },
+
+  initialize: function(options) {
+    // Initialize Shareabouts Vote App
+
+    console.log('You have access to the following as Shareabouts.bootstrapped:');
+    console.log(Shareabouts.bootstrapped);
+
+    console.log('You have access to the following as Shareabouts.config:');
+    console.log(Shareabouts.config);
+  },
+
+  homeRoute: function() {
+  },
+
+  faqRoute: function() {
+  },
+});
+
+export { Router };

--- a/src/sa_vote/templates/sa_vote/base.html
+++ b/src/sa_vote/templates/sa_vote/base.html
@@ -1,0 +1,197 @@
+{% load jstemplate %}
+{% load i18n %}
+{% load shareabouts_utils %}
+{% load static %}
+{% load django_vite %}
+{% get_current_language as LANGUAGE_CODE %}
+
+<!DOCTYPE html>
+<html lang="{{LANGUAGE_CODE}}" dir="auto">
+<head>
+  <meta charset="utf-8">
+  <title>{{ config.app.title }}</title>
+  <meta name="description" content="{{ config.app.meta_description }}">
+  <meta name="author" content="{{ config.app.meta_author }}">
+
+  <!-- Social Media meta tags and such -->
+  {% block meta %}{% endblock %}
+
+  <!-- Mobile Viewport Fix -->
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, minimal-ui" />
+
+  {% block app_icons %}
+  <!-- Favicon & Progressively-Enhanced Touch Icons: http://mathiasbynens.be/notes/touch-icons#sizes -->
+  <link rel="shortcut icon" href="{{ config.static_url }}css/images/favicon.ico">
+  <link rel="apple-touch-icon-precomposed" sizes="144x144" href="{{ config.static_url }}css/images/apple-touch-icon-144x144-precomposed.png">
+  <link rel="apple-touch-icon-precomposed" sizes="114x114" href="{{ config.static_url }}css/images/apple-touch-icon-114x114-precomposed.png">
+  <link rel="apple-touch-icon-precomposed" sizes="72x72" href="{{ config.static_url }}css/images/apple-touch-icon-72x72-precomposed.png">
+  <link rel="apple-touch-icon-precomposed" href="{{ config.static_url }}css/images/apple-touch-icon-precomposed.png">
+  {% endblock app_icons %}
+
+  <!-- Google WebFonts -->
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Dancing+Script:wght@700&family=Lora:ital@0;1&family=Mada:wght@400;700&family=Markazi+Text&family=Montserrat:ital,wght@0,100..900;1,100..900&display=swap" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css2?family=Covered+By+Your+Grace&display=swap" rel="stylesheet">
+
+  {% if settings.DEBUG %}
+  <link rel="stylesheet" href="{% static 'css/normalize.css' %}">
+  <link rel="stylesheet" href="{% static 'css/default.css' %}">
+  {% else %}
+  <link rel="stylesheet" href="{% static 'dist/app.css' %}?_={{settings.LAST_DEPLOY_DATE}}">
+  {% endif %}
+
+  <!-- Base PB Boston Stylesheet -->
+  <link rel="stylesheet" href="{% static 'css/pbboston.css' %}?_={{settings.LAST_DEPLOY_DATE}}">
+
+  <!-- Flavor's Custom Stylesheet -->
+  <link rel="stylesheet" href="{% static 'css/custom.css' %}?_={{settings.LAST_DEPLOY_DATE}}">
+
+
+  <link rel="profile" href="http://gmpg.org/xfn/11" />
+
+  {% vite_hmr_client %}
+</head>
+<body class="{% if config.map.geocoding_enabled %} geocoding-enabled{% endif %}">
+  {% block sentry_init %}
+    {% if settings.RAVEN_CONFIG.public_dsn %}{% include '_sentry_init.html' %}{% endif %}
+  {% endblock %}
+
+  <header id="site-header" class="clearfix{% if pages_config %} has-pages{% endif %}">
+    {% block header_intro %}{% endblock %}
+
+    <h1 id="site-title">{% block site-title %}{% endblock %}</h1>
+
+    {% block pre_auth_nav %}{% endblock %}
+    <div id="auth-nav-container"></div>
+    {% block post_auth_nav %}{% endblock %}
+
+    {% block pre_pages_nav %}{% endblock %}
+    <div id="pages-nav-container"></div>
+    {% block post_pages_nav %}{% endblock %}
+
+    {% if config.languages %}
+      {% include 'language_picker.html' %}
+    {% endif %}
+
+  </header>
+
+  <main id="app">
+    {% block main %}{% endblock %}
+  </main><!-- end #app -->
+
+  <footer id="colophon">
+    {% block colophon %}{% endblock %}
+  </footer>
+
+  <!-- Grab Google CDN's jQuery, with a protocol relative URL; fall back to local if offline -->
+  <script src="//ajax.googleapis.com/ajax/libs/jquery/1.10.2/jquery.min.js"></script>
+  <script>window.jQuery || document.write('<script src="{{ STATIC_URL }}libs/jquery-1.10.2.js"><\/script>')</script><!-- FIXME: Maybe this should be pulled into the repo as a git submodule-->
+
+  {% block cdn_load %}{% endblock %}
+
+  {% if settings.DEBUG %}
+  <script src="{% static 'libs/underscore.js' %}"></script>
+  <script src="{% static 'libs/backbone.js' %}"></script>
+  <script src="{% static 'libs/backbone.marionette.js' %}"></script>
+  <script src="{% static 'libs/handlebars-v3.0.3.js' %}"></script>
+  <script src="{% static 'libs/moment-with-locales.min.js' %}"></script>
+  <script src="{% static 'libs/binaryajax.js' %}"></script>
+  <script src="{% static 'libs/exif.js' %}"></script>
+  <script src="{% static 'libs/load-image.js' %}"></script>
+  <script src="{% static 'libs/gatekeeper.js' %}"></script>
+  <script src="{% static 'libs/swag.min.js' %}"></script>
+
+  <script src="{% static 'js/utils.js' %}"></script>
+  <script src="{% static 'js/template-helpers.js' %}"></script>
+  <!-- https://github.com/openplans/handlebars-helpers -->
+  <script src="{% static 'libs/handlebars-helpers.js' %}"></script>
+  {% else %}
+  <script src="{% static 'dist/libs.min.js' %}?_={{settings.LAST_DEPLOY_DATE}}"></script>
+  <script src="{% static 'dist/preload.js' %}?_={{settings.LAST_DEPLOY_DATE}}"></script>
+  {% endif %}
+
+  <!-- Register Handlebars helpers from Swag -->
+  <script>Swag.registerHelpers(Handlebars);</script>
+
+  <script>
+    moment.locale('{{LANGUAGE_CODE}}');
+  </script>
+
+  <!-- Bootstrap site and user information -->
+  <script>
+    Shareabouts.bootstrapped = {
+      dataset: {{ DATASET_ROOT|as_json }},
+      staticUrl: '{{ STATIC_URL }}',
+      languageCode: '{{ LANGUAGE_CODE }}',
+      mapboxToken: '{{ settings.MAPBOX_TOKEN }}',
+      routePrefix: {{ route_prefix | as_json }},
+      apiPrefix:  {{ api_prefix | as_json }},
+    };
+
+    function bootstrapCurrentUser(data) {
+      Shareabouts.bootstrapped.currentUser = data;
+    }
+
+    bootstrapCurrentUser({{ api_user | as_json }});
+  </script>
+
+  {% if settings.DEBUG %}
+  <script src="{% static 'js/handlebars-helpers.js' %}"></script>
+  <script src="{% static 'js/models.js' %}"></script>
+  <script src="{% static 'js/views/pages-nav-view.js' %}"></script>
+  {% else %}
+  <script src="{% static 'dist/app.js' %}?_={{settings.LAST_DEPLOY_DATE}}"></script>
+  {% endif %}
+
+  {% comment %} <script src="{{API_ROOT}}users/current?format=jsonp&callback=bootstrapCurrentUser"></script> {% endcomment %}
+
+  {% handlebarsjs '(.*)' precompile register_partials %}
+  {% handlebarsjs 'pages/*' precompile %}
+
+  <script type="text/javascript">
+    // Boostrapping the place types and their icons
+    Shareabouts.Config = Shareabouts.config = {
+      defaultPlaceTypeName: '{{ default_place_type }}',
+      userToken: (
+        Shareabouts.bootstrapped.currentUser ?
+        'user:' + Shareabouts.bootstrapped.currentUser.id :
+        {{ user_token_json|safe }}),
+
+      routePrefix: Shareabouts.bootstrapped.routePrefix,
+      apiPrefix: Shareabouts.bootstrapped.apiPrefix,
+
+      flavor:     {{ config.data|as_json }},
+      place:      {{ config.place|as_json }},
+      placeTypes: {{ config.place_types|as_json }},
+      survey:     {{ config.survey|as_json }},
+      support:    {{ config.support|as_json }},
+      map:        {{ config.map|as_json }},
+      activity:   {{ config.activity|as_json }},
+      pages:      {{ pages_config_json|safe }}
+    };
+  </script>
+
+  {% if settings.GOOGLE_ANALYTICS_ID %}
+  <!-- Google tag (gtag.js) -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id={{ settings.GOOGLE_ANALYTICS_ID }}"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+
+    gtag('config', '{{ settings.GOOGLE_ANALYTICS_ID }}', { 
+      'cookie_flags': 'SameSite=None; Secure',
+      'send_page_view': false,
+    });
+    gtag('event', 'page_view', {
+      page_title: document.title,
+      page_location: window.location.pathname,
+    });
+  </script>
+  {% endif %}
+
+  {% block includes %}{% endblock %}
+
+</body>
+</html>

--- a/src/sa_vote/templates/sa_vote/index.html
+++ b/src/sa_vote/templates/sa_vote/index.html
@@ -1,0 +1,81 @@
+{% extends 'sa_vote/base.html' %}
+{% load i18n %}
+{% load static %}
+{% load django_vite %}
+
+{% block header_intro %}
+<div id="boston-small-screen-lead-in" class="boston-small-screen-lead-in">
+  <img class="boston-logo" alt="" src="{% static 'css/images/boston-logo-white.png' %}"><br>
+  <span class="pb-label">{% translate "Participatory Budgeting" %}</span>
+</div>
+{% endblock %}
+
+{% block site-title %}
+<a href="/{{ config.app.home_path }}" data-internal="true">
+  <img class="boston-icon" alt="" src="{% static 'css/images/boston-icon-light.svg' %}">
+  <img class="pb-icon" alt="" src="{% static 'css/images/pbboston-icon.svg' %}">
+  <img class="boston-logo" alt="" src="{% static 'css/images/boston-logo.svg' %}">
+  <span class="pb-label">{% translate "Participatory Budgeting" %}</span>
+</a>
+{% endblock %}
+
+{% block meta %}
+  {% if place %}
+    <!-- Twitter -->
+    <meta name="twitter:card" content="summary">
+    <meta name="twitter:title" content="{{ place.properties.name }}">
+    <meta name="twitter:description" content="{{ place.properties.description }}">
+    {% with attachment=place.properties.attachments|first %}
+    <meta name="twitter:image:src" content="{{ attachment.file }}">
+    {% endwith %}
+    {% comment %} TODO: Fill this in when we know if the username is from twitter
+      <meta name="twitter:creator" content="place.submitter.username">
+    {% endcomment %}
+
+    <!-- Facebook -->
+    <meta property="og:site_name" content="{{ config.app.title }}" />
+    <meta property="og:title" content="{{ place.properties.name }}" />
+    <meta property="og:description" content="{{ place.properties.description }}" />
+    {% with attachment=place.properties.attachments|first %}
+    <meta name="og:image" content="{{ attachment.file }}">
+    {% endwith %}
+  {% else %}
+    <!-- Twitter -->
+    <meta name="twitter:card" content="summary">
+    <meta name="twitter:title" content="{{ config.app.title }}">
+    <meta name="twitter:description" content="{{ config.app.meta_description }}">
+
+    <!-- Facebook -->
+    <meta property="og:site_name" content="{{ config.app.title }}" />
+    <meta property="og:title" content="{{ config.app.title }}" />
+    <meta property="og:description" content="{{ config.app.meta_description }}" />
+  {% endif%}
+{% endblock %}
+
+{% block pre_pages_nav %}
+{% endblock %}
+
+<!--
+  This will place content in the colophon below the map
+ -->
+{% block colophon %}
+
+<p id="powered-by">
+  <span class="nobreak">{% blocktrans with Shareabouts='<a href="https://github.com/openplans/shareabouts" class="shareabouts-logo" target="_blank">Shareabouts</a>' %}Powered by {{Shareabouts}}{% endblocktrans %}</span>,
+  <span class="nobreak">{% blocktrans with PoePublic='<a href="mailto:hello@poepublic.com" class="poepublic-logo" target="_blank">Poe<strong>Public</strong></a>' %}built by {{PoePublic}}{% endblocktrans %}</span></p>
+{% endblock %}
+
+<!--
+  Analytics, custom JS, and such go here
+ -->
+{% block includes %}
+<script>
+  Shareabouts.bootstrapped.neighborhoods = {{ neighborhoods|safe }};
+  Shareabouts.bootstrapped.site_root = '{{ site_root }}';
+</script>
+
+<script src="{% static 'js/language-picker.js' %}"></script>
+<script src="{% static 'js/pages-nav-previous-cycles-menu-ext.js' %}"></script>
+
+{% vite_asset 'sa_vote/main.js' %}
+{% endblock %}

--- a/src/sa_vote/urls.py
+++ b/src/sa_vote/urls.py
@@ -1,0 +1,13 @@
+from django.urls import path
+
+from . import views
+
+urlpatterns = [
+    # The following rule ensures that the index view is used even if the user
+    # does not include a trailing slash in the URL:
+    path("", views.index),
+
+    # Any paths not matched by some other explicit patter will fall back to the
+    # following rule:
+    path("<path:frontend_path>", views.index),
+]

--- a/src/sa_vote/views.py
+++ b/src/sa_vote/views.py
@@ -1,3 +1,58 @@
+import json
+
+from django.conf import settings
 from django.shortcuts import render
+from django.views.decorators.csrf import ensure_csrf_cookie
+
+from sa_util.api import ShareaboutsApi
+from sa_util.config import get_shareabouts_config
+from pbboston.geodata import load_neighborhoods, load_city
+from sa_web.views import apply_language, calc_adding_support, get_shareabouts_user_token, process_shareabouts_config, show_prelaunch_until_go_live_date
+
 
 # Create your views here.
+@ensure_csrf_cookie
+@apply_language
+@process_shareabouts_config
+@show_prelaunch_until_go_live_date
+def index(request, frontend_path=None):
+    api = ShareaboutsApi(request.shareabouts_config, request)
+
+    # Get the content of the static pages linked in the menu.
+    pages_config = request.shareabouts_config.get('pages', [])
+    pages_config_json = json.dumps(pages_config)
+
+    # Instead of loading the place (idea) configuration, load
+    # the voting configuration and ballot proposals.
+    ballot_config = request.shareabouts_config.get('ballot', {})
+    assert isinstance(ballot_config, dict), 'Ballot configuration must be a dictionary.'
+
+    ballot_config['adding_supported'] = calc_adding_support(ballot_config.get('adding_supported'))
+
+    user_token_json = json.dumps(get_shareabouts_user_token(request))
+
+    neighborhoods = load_neighborhoods()
+    path_prefix = settings.BASE_URL
+
+    context = {'config': request.shareabouts_config,
+
+               'route_prefix': path_prefix + '/vote',
+               'api_prefix': path_prefix + '/api',
+
+               'user_token_json': user_token_json,
+               'pages_config': pages_config,
+               'pages_config_json': pages_config_json,
+
+               'API_ROOT': api.root,
+               'DATASET_ROOT': api.dataset_root,
+
+               'api_user': api.current_user(default=None),
+
+               # Geo-data for Boston
+               'neighborhoods': neighborhoods,
+
+               # Site root useful for automatic translation
+               'site_root': settings.SITE_ROOT,
+               }
+
+    return api.respond_with_session_cookie(render(request, 'sa_vote/index.html', context))

--- a/vite.config.js
+++ b/vite.config.js
@@ -18,6 +18,7 @@ export default defineConfig({
       input: {
         'sa_admin-dashboard': djangoStatic('sa_admin/dashboard/main.js'),
         'sa_admin-detail': djangoStatic('sa_admin/detail/main.js'),
+        'sa_vote': djangoStatic('sa_vote/main.js'),
       },
       external: ['leaflet'],
       output: {


### PR DESCRIPTION
- Add _main.js_ and _routes.js_ front-end modules
  - _main.js_ should contain limited app initialization code
  - _routes.js_ should contain anything that will happen when the user goes to a new path in the app. For the most part, changes in app state should be done by sending the user to a new route (e.g. search for `router.navigate` in `sa_web`) as if you're sending them to a new page
- Add `sa_vote` app to the list of `INSTALLED_APPS` for the Django project
- Route Django traffic starting with _/vote_ to the `sa_vote` app
- Add a stub module for ballot handling in Python
- Add the `sa_vote` app assets to the Vite config

To run, in one terminal run
```sh
npm run dev
```

And in another terminal run
```sh
src/manage.py runserver # Prefix with `dotenv`, same as befpre
```

Related to #160
Resolves #161 