### PR TITLE
Stub out testing endpoint for login code verification

### DIFF
--- a/src/project/urls.py
+++ b/src/project/urls.py
@@ -4,6 +4,7 @@ from django.contrib.staticfiles.urls import staticfiles_urlpatterns
 from django.contrib import admin
 from django.views.i18n import set_language
 from sa_login import views as auth_views
+from sa_vote import views as vote_views
 
 
 from urllib.parse import urlparse
@@ -22,7 +23,8 @@ urlpatterns = staticfiles_urlpatterns() + [
     path(base_path + 'users/begin/<provider>', auth_views.oauth_begin, name='oauth_begin'),
     path(base_path + 'users/complete/<provider>', auth_views.oauth_complete, name='oauth_complete'),
     path(base_path + 'admin/', include('sa_admin.urls')),
-    path(base_path + 'vote', include('sa_vote.urls')),
+    path(base_path + 'vote', vote_views.index),
+    path(base_path + 'vote/', include('sa_vote.urls')),
     path(base_path + '', include('sa_web.urls')),
 ]
 

--- a/src/project/urls.py
+++ b/src/project/urls.py
@@ -2,9 +2,9 @@ from django.urls import include, path
 from django.conf import settings
 from django.contrib.staticfiles.urls import staticfiles_urlpatterns
 from django.contrib import admin
+from django.http import HttpResponseRedirect
 from django.views.i18n import set_language
 from sa_login import views as auth_views
-from sa_vote import views as vote_views
 
 
 from urllib.parse import urlparse
@@ -23,7 +23,7 @@ urlpatterns = staticfiles_urlpatterns() + [
     path(base_path + 'users/begin/<provider>', auth_views.oauth_begin, name='oauth_begin'),
     path(base_path + 'users/complete/<provider>', auth_views.oauth_complete, name='oauth_complete'),
     path(base_path + 'admin/', include('sa_admin.urls')),
-    path(base_path + 'vote', vote_views.index),
+    path(base_path + 'vote', lambda _: HttpResponseRedirect(base_path + 'vote/')),
     path(base_path + 'vote/', include('sa_vote.urls')),
     path(base_path + '', include('sa_web.urls')),
 ]

--- a/src/sa_vote/templates/sa_vote/base.html
+++ b/src/sa_vote/templates/sa_vote/base.html
@@ -127,6 +127,9 @@
       mapboxToken: '{{ settings.MAPBOX_TOKEN }}',
       routePrefix: {{ route_prefix | as_json }},
       apiPrefix:  {{ api_prefix | as_json }},
+      
+      voterIdHash: {{ request.session.voter_id_hash | as_json }},
+      voterVerified: {{ request.session.voter_verified | as_json }},
     };
 
     function bootstrapCurrentUser(data) {

--- a/src/sa_vote/tests.py
+++ b/src/sa_vote/tests.py
@@ -1,3 +1,176 @@
-from django.test import TestCase
+import json
+from hashlib import sha256
 
-# Create your tests here.
+from django.http import Http404
+from django.test import Client, override_settings, RequestFactory, SimpleTestCase
+
+
+class NormalizePhoneNumberTests(SimpleTestCase):
+    """Unit tests for the normalize_phone_number utility."""
+
+    def test_strips_non_digits_from_phone_number(self):
+        from sa_vote.views import normalize_phone_number
+        result = normalize_phone_number('1', '555-123-4567')
+        self.assertEqual(result, '+15551234567')
+
+    def test_strips_plus_from_country_code(self):
+        from sa_vote.views import normalize_phone_number
+        result = normalize_phone_number('+1', '555-123-4567')
+        self.assertEqual(result, '+15551234567')
+
+    def test_strips_parens_and_spaces_from_phone_number(self):
+        from sa_vote.views import normalize_phone_number
+        result = normalize_phone_number('1', '(555) 123 4567')
+        self.assertEqual(result, '+15551234567')
+
+    def test_handles_international_country_code(self):
+        from sa_vote.views import normalize_phone_number
+        result = normalize_phone_number('44', '7911 123456')
+        self.assertEqual(result, '+447911123456')
+
+    def test_handles_dots_in_phone_number(self):
+        from sa_vote.views import normalize_phone_number
+        result = normalize_phone_number('1', '555.123.4567')
+        self.assertEqual(result, '+15551234567')
+
+
+@override_settings(DEBUG=True)
+class VerifyCodeTestViewUnitTests(SimpleTestCase):
+    """Unit tests for verify_code_test using RequestFactory (no URL routing)."""
+
+    def test_valid_code_returns_204(self):
+        from sa_vote.views import verify_code_test
+        request = RequestFactory().get('/', {'code': '123456'})
+        request.session = {}
+        response = verify_code_test(request)
+        self.assertEqual(response.status_code, 204)
+
+    def test_valid_code_sets_voter_verified_on_session(self):
+        from sa_vote.views import verify_code_test
+        request = RequestFactory().get('/', {'code': '123456'})
+        request.session = {}
+        verify_code_test(request)
+        self.assertTrue(request.session.get('voter_verified'))
+
+    def test_valid_code_sets_voter_id_hash_on_session(self):
+        from sa_vote.views import verify_code_test, normalize_phone_number
+        request = RequestFactory().get('/', {'code': '123456'})
+        request.session = {}
+        verify_code_test(request)
+
+        expected_id = normalize_phone_number('1', '555-123-4567')
+        expected_hash = sha256(expected_id.encode('utf-8')).hexdigest()
+        self.assertEqual(request.session.get('voter_id_hash'), expected_hash)
+
+    def test_invalid_code_returns_404(self):
+        from sa_vote.views import verify_code_test
+        request = RequestFactory().get('/', {'code': '000000'})
+        request.session = {}
+        response = verify_code_test(request)
+        self.assertEqual(response.status_code, 404)
+        data = json.loads(response.content)
+        self.assertIn('error', data)
+
+    def test_invalid_code_does_not_set_session(self):
+        from sa_vote.views import verify_code_test
+        request = RequestFactory().get('/', {'code': 'wrong'})
+        request.session = {}
+        verify_code_test(request)
+        self.assertNotIn('voter_id_hash', request.session)
+        self.assertNotIn('voter_verified', request.session)
+
+    def test_missing_code_returns_400(self):
+        from sa_vote.views import verify_code_test
+        request = RequestFactory().get('/')
+        request.session = {}
+        response = verify_code_test(request)
+        self.assertEqual(response.status_code, 400)
+        data = json.loads(response.content)
+        self.assertIn('error', data)
+
+    @override_settings(DEBUG=False)
+    def test_raises_404_when_debug_is_false(self):
+        from sa_vote.views import verify_code_test
+        request = RequestFactory().get('/', {'code': '123456'})
+        request.session = {}
+        with self.assertRaises(Http404):
+            verify_code_test(request)
+
+
+class UnverifyViewUnitTests(SimpleTestCase):
+    """Unit tests for unverify using RequestFactory (no URL routing)."""
+
+    def test_returns_204(self):
+        from sa_vote.views import unverify
+        request = RequestFactory().get('/')
+        request.session = {}
+        response = unverify(request)
+        self.assertEqual(response.status_code, 204)
+
+    def test_clears_voter_id_hash_from_session(self):
+        from sa_vote.views import unverify
+        request = RequestFactory().get('/')
+        request.session = {'voter_id_hash': 'abc123', 'voter_verified': True}
+        unverify(request)
+        self.assertNotIn('voter_id_hash', request.session)
+
+    def test_clears_voter_verified_from_session(self):
+        from sa_vote.views import unverify
+        request = RequestFactory().get('/')
+        request.session = {'voter_id_hash': 'abc123', 'voter_verified': True}
+        unverify(request)
+        self.assertNotIn('voter_verified', request.session)
+
+    def test_is_safe_on_fresh_session(self):
+        from sa_vote.views import unverify
+        request = RequestFactory().get('/')
+        request.session = {}
+        # Should not raise
+        response = unverify(request)
+        self.assertEqual(response.status_code, 204)
+
+
+class VerifyCodeUnitTests(SimpleTestCase):
+    """Tests for the verify_code endpoint."""
+    pass
+
+
+@override_settings(DEBUG=True)
+class VerifyCodeTestIntegrationTests(SimpleTestCase):
+    """
+    Integration tests hitting the actual URL routing via Django test Client.
+
+    Note: sa_vote.urls is included under path('vote', ...) with no trailing
+    slash, so the resolved paths are /vote/verify-code-test, /vote/verify-code,
+    and /vote/unverify.
+    """
+
+    def test_valid_code_sets_session_via_url(self):
+        client = Client()
+        response = client.get('/vote/verify-code-test', {'code': '123456'})
+        self.assertEqual(response.status_code, 204)
+        self.assertTrue(client.session.get('voter_verified'))
+        self.assertIsNotNone(client.session.get('voter_id_hash'))
+
+    def test_invalid_code_via_url(self):
+        client = Client()
+        response = client.get('/vote/verify-code-test', {'code': 'bad'})
+        self.assertEqual(response.status_code, 404)
+
+    def test_unverify_clears_session_via_url(self):
+        client = Client()
+        # Verify first
+        response = client.get('/vote/verify-code-test', {'code': '123456'})
+        self.assertEqual(response.status_code, 204)
+        self.assertTrue(client.session.get('voter_verified'))
+
+        # Then unverify
+        response = client.get('/vote/unverify')
+        self.assertEqual(response.status_code, 204)
+        self.assertIsNone(client.session.get('voter_id_hash'))
+        self.assertIsNone(client.session.get('voter_verified'))
+
+    def test_verify_code_stub_via_url(self):
+        client = Client()
+        response = client.get('/vote/verify-code')
+        self.assertEqual(response.status_code, 400)

--- a/src/sa_vote/urls.py
+++ b/src/sa_vote/urls.py
@@ -3,9 +3,9 @@ from django.urls import path
 from . import views
 
 urlpatterns = [
-    # The following rule ensures that the index view is used even if the user
-    # does not include a trailing slash in the URL:
-    path("", views.index),
+    path("verify-code", views.verify_code),
+    path("verify-code-test", views.verify_code_test),  # Only available when DEBUG=True
+    path("unverify", views.unverify),
 
     # Any paths not matched by some other explicit patter will fall back to the
     # following rule:

--- a/src/sa_vote/urls.py
+++ b/src/sa_vote/urls.py
@@ -8,6 +8,7 @@ urlpatterns = [
     path("unverify", views.unverify),
 
     # Any paths not matched by some other explicit patter will fall back to the
-    # following rule:
+    # following rules:
+    path("", views.index),
     path("<path:frontend_path>", views.index),
 ]

--- a/src/sa_vote/views.py
+++ b/src/sa_vote/views.py
@@ -1,6 +1,8 @@
 import json
+from hashlib import sha256
 
 from django.conf import settings
+from django.http import Http404, HttpRequest, HttpResponse, JsonResponse
 from django.shortcuts import render
 from django.views.decorators.csrf import ensure_csrf_cookie
 
@@ -8,6 +10,55 @@ from sa_util.api import ShareaboutsApi
 from sa_util.config import get_shareabouts_config
 from pbboston.geodata import load_neighborhoods, load_city
 from sa_web.views import apply_language, calc_adding_support, get_shareabouts_user_token, process_shareabouts_config, show_prelaunch_until_go_live_date
+
+
+def normalize_phone_number(country_code: str,phone_number: str) -> str:
+    """
+    Normalize a phone number to a standard E.164 format for comparison.
+    """
+    cc_digits = ''.join(filter(str.isdigit, country_code))
+    pn_digits = ''.join(filter(str.isdigit, phone_number))
+    return f'+{cc_digits}{pn_digits}'
+
+
+def verify_code(request: HttpRequest) -> HttpResponse:
+    return JsonResponse({'error': 'Not implemented'}, status=400)
+
+
+def unverify(request: HttpRequest) -> HttpResponse:
+    """
+    A view to unverify a voter.
+    - Should remove the voter_id_hash and voter_verified from the session.
+    """
+    request.session.pop('voter_id_hash', None)
+    request.session.pop('voter_verified', None)
+    return HttpResponse(status=204)
+
+
+def verify_code_test(request: HttpRequest) -> HttpResponse:
+    """
+    A test view to verify a voter code.
+    - Should only be available when `DEBUG=True`.
+    - Should accept a `code` query string parameter via GET for simplicity.
+    - Should use hard-coded codes for testing:
+        - `123456` is a valid code for a user and will get written to the session and return a 204 response
+        - Anything else will result in a 404 invalid code
+    """
+    if not settings.DEBUG:
+        raise Http404
+    
+    code = request.GET.get('code')
+
+    if code is None:
+        return JsonResponse({'error': 'Missing "code" parameter'}, status=400)
+    elif code == '123456':
+        fake_id = normalize_phone_number('1', '555-123-4567')
+        fake_id_hash = sha256(fake_id.encode('utf-8')).hexdigest()
+        request.session['voter_id_hash'] = fake_id_hash
+        request.session['voter_verified'] = True
+        return HttpResponse(status=204)
+    else:
+        return JsonResponse({'error': 'Invalid code'}, status=404)
 
 
 # Create your views here.

--- a/src/sa_vote/views.py
+++ b/src/sa_vote/views.py
@@ -1,5 +1,6 @@
 import json
 from hashlib import sha256
+from collections.abc import Callable
 
 from django.conf import settings
 from django.http import Http404, HttpRequest, HttpResponse, JsonResponse
@@ -12,7 +13,7 @@ from pbboston.geodata import load_neighborhoods, load_city
 from sa_web.views import apply_language, calc_adding_support, get_shareabouts_user_token, process_shareabouts_config, show_prelaunch_until_go_live_date
 
 
-def normalize_phone_number(country_code: str,phone_number: str) -> str:
+def normalize_phone_number(country_code: str, phone_number: str) -> str:
     """
     Normalize a phone number to a standard E.164 format for comparison.
     """
@@ -21,20 +22,31 @@ def normalize_phone_number(country_code: str,phone_number: str) -> str:
     return f'+{cc_digits}{pn_digits}'
 
 
+def init_voter_verification_session(view_func: Callable[..., HttpResponse]) -> Callable[..., HttpResponse]:
+    """
+    A decorator to ensure that the session has the voter_id_hash and voter_verified keys.
+    If they are not present, they will be initialized to None and False respectively.
+    """
+    def wrapped_view(request: HttpRequest, *args, **kwargs):
+        if 'voter_id_hash' not in request.session:
+            request.session['voter_id_hash'] = None
+        if 'voter_verified' not in request.session:
+            request.session['voter_verified'] = False
+        return view_func(request, *args, **kwargs)
+    return wrapped_view
+
+
+@init_voter_verification_session
 def verify_code(request: HttpRequest) -> HttpResponse:
-    return JsonResponse({'error': 'Not implemented'}, status=400)
-
-
-def unverify(request: HttpRequest) -> HttpResponse:
     """
-    A view to unverify a voter.
-    - Should remove the voter_id_hash and voter_verified from the session.
+    A view to verify a voter code. Accepts code via POST. If code is valid
+    should set the voter_id_hash and voter_verified in the session and return a
+    204 response. If code is invalid should return a 404.
     """
-    request.session.pop('voter_id_hash', None)
-    request.session.pop('voter_verified', None)
-    return HttpResponse(status=204)
+    return JsonResponse({'error': 'Not implemented'}, status=501)
 
 
+@init_voter_verification_session
 def verify_code_test(request: HttpRequest) -> HttpResponse:
     """
     A test view to verify a voter code.
@@ -61,11 +73,21 @@ def verify_code_test(request: HttpRequest) -> HttpResponse:
         return JsonResponse({'error': 'Invalid code'}, status=404)
 
 
-# Create your views here.
+def unverify(request: HttpRequest) -> HttpResponse:
+    """
+    A view to unverify a voter.
+    - Should remove the voter_id_hash and voter_verified from the session.
+    """
+    request.session['voter_id_hash'] = None
+    request.session['voter_verified'] = False
+    return HttpResponse(status=204)
+
+
 @ensure_csrf_cookie
 @apply_language
 @process_shareabouts_config
 @show_prelaunch_until_go_live_date
+@init_voter_verification_session
 def index(request, frontend_path=None):
     api = ShareaboutsApi(request.shareabouts_config, request)
 


### PR DESCRIPTION
- Resolves #180
### What this does

Adds a `/vote/verify-code-test` endpoint that simulates the login code verification flow (see #153) using hard-coded values, so the frontend can be developed and tested without Redis or SMS infrastructure. _Note: the endpoint responds with a `204 No Content` response if it's successful, so if you go to http://localhost:8000/vote/verify-code-test in your browser, no output is good output._

Also adds:
- `/vote/unverify` — clears the voter session, useful for resetting state during testing
- `/vote/verify-code` — stub for the real endpoint (#153), currently returns `400 Not Implemented`
- `normalize_phone_number()` — utility to normalize phone numbers to E.164 format (shared with the future real endpoint)

### Try it out...

1.  Start up a server (`npm run dev` and `manage.py runserver`), go to http://localhost:8000/vote/, and pull up a developer console. Run the following:

    ```js
    Shareabouts.bootstrapped.voterIdHash;
    Shareabouts.bootstrapped.voterVerified;
    ```

    You should see `null` and `false` in the console.

2.  Now, in a new tab, go to http://localhost:8000/vote/verify-code-test?code=123456. You may just see a blank new tab. That's normal (the Django view responds with an `HTTP 204 No Response` code, which is used to denote that the request was successful, but there's nothing else to report back).

3.  Go back to the tab with http://localhost:8000/vote/. Refresh the page and in the dev console, run this again:

    ```js
    Shareabouts.bootstrapped.voterIdHash;
    Shareabouts.bootstrapped.voterVerified;
    ```

    Now you should see `"8a59780bb8cd2ba022bfa5ba2ea3b6e07af17a7d8b30c1f9b3390e36f69019e4"` and `true`.

4.  In another tab (it can be the one you used for `verify-code-test` before, or a new one), go to http://localhost:8000/vote/unverify. You will probably get no discernible response again (`HTTP 204`).

5.  Go back to the tab with http://localhost:8000/vote/. Refresh the page and in the dev console, run this again:

    ```js
    Shareabouts.bootstrapped.voterIdHash;
    Shareabouts.bootstrapped.voterVerified;
    ```

    You should again see `null` and `false` in the console.

The `/vote/verify-code-test` endpoint is only available when the server's `DEBUG` setting is set to `True`. Otherwise the view responds with a `404` regardless of the code provided.

### Session state set on success

The user's session is set on the server side and is correlated with the user's browser using a cookie. Here's how it works: Django's session framework gives each browser a unique **session ID**, which it stores in a cookie called `sa-web-session`. The actual session data (like `voter_id_hash` and `voter_verified`) is stored on the server — the browser never sees those values directly in the cookie. When the browser makes a request, Django reads the session ID from the cookie, looks up the corresponding data on the server, and makes it available to view code via `request.session` (which behaves like a Python dictionary).

In local development, the session data is stored in a signed cookie (all on the client side, for simplicity). In production, it's stored in Redis — Django uses Redis as a cache backend and stores sessions there, so the server can look up session data by session ID on each request. Either way, the mechanism is the same from the view's perspective: `request.session['voter_id_hash'] = ...` saves it, and `request.session.get('voter_id_hash')` reads it back on the next request.

The browser-side JavaScript doesn't read the session cookie directly. Instead, when Django renders the page template, it reads the session values and writes them into the HTML as JavaScript variables (in `base.html`, inside the `Shareabouts.bootstrapped` object). So the flow is: **view sets session → browser stores session cookie → next page load sends cookie → Django looks up session → template renders session values into JS → frontend reads `Shareabouts.bootstrapped.voterVerified`**.

```mermaid
sequenceDiagram
    autonumber
    actor Browser
    participant Django
    participant Session as Session Store<br/>(signed cookie locally,<br/>Redis in production)

    Note over Browser,Session: 1. Verify code request

    Browser->>Django: GET /vote/verify-code-test?code=123456
    Django->>Session: Store voter_id_hash, voter_verified=True
    Django-->>Browser: 204 No Content + Set-Cookie (session ID)
    Note over Browser: Browser saves session cookie

    Note over Browser,Session: 2. Next page load

    Browser->>Django: GET /vote/ (cookie: session ID)
    Django->>Session: Look up session by ID
    Session-->>Django: {voter_id_hash: "8a59...", voter_verified: True}
    Django-->>Browser: HTML with Shareabouts.bootstrapped.voterVerified = true
    Note over Browser: JS reads Shareabouts.bootstrapped
```

| Session Key        | Value                                                |
|--------------------|------------------------------------------------------|
| `voter_id_hash`    | SHA-256 of normalized fake phone number `+15551234567` |
| `voter_verified`   | `True`                                               |

This matches the session contract that the real `/vote/verify-code` endpoint will use (#153).

### Tests

20 tests added in `sa_vote/tests.py`:

| Test Class | Count | Coverage |
|---|---|---|
| `NormalizePhoneNumberTests` | 5 | Various input formats (dashes, parens, spaces, dots, international codes) |
| `VerifyCodeTestViewUnitTests` | 7 | Valid → 204 + session, invalid → 404, missing → 400, no session leak, `Http404` when `DEBUG=False` |
| `UnverifyViewUnitTests` | 4 | Returns 204, clears both session keys, safe on empty session |
| `VerifyCodeTestIntegrationTests` | 4 | End-to-end through URL routing with Django test `Client` |

### Files changed

- `src/project/urls.py` — split vote URL include to serve `index` at `/vote` and sub-routes at `/vote/`
- `src/sa_vote/urls.py` — add `verify-code`, `verify-code-test`, `unverify` routes
- `src/sa_vote/views.py` — add `normalize_phone_number`, `verify_code`, `unverify`, `verify_code_test` views
- `src/sa_vote/tests.py` — 21 new tests
- `src/sa_vote/templates/sa_vote/base.html` — add voter verification status into bootstrapped `Shareabouts` data
